### PR TITLE
DAC-253: Add projected work into status messages.

### DIFF
--- a/src/Plutus/Certification/Server.hs
+++ b/src/Plutus/Certification/Server.hs
@@ -89,7 +89,7 @@ server ServerCaps {..} eb = NamedAPI
           (_, Building _) -> s
           (Building _, _) -> s'
 
-          (Certifying st mp, Certifying st' mp') -> case compare st st' of
+          (Certifying (CertifyingStatus st mp _), Certifying (CertifyingStatus st' mp' _)) -> case compare st st' of
             LT -> s'
             GT -> s
             EQ -> case (mp, mp') of


### PR DESCRIPTION
In the "certifying" state, there may be a new "plan" field with a list of CertificationTask objects corresponding to the tasks that will run during the job.

The "qc-progress" and "qc-result" fields may have a new "expected" field with a total number of QuickCheck tests to run in that task.

A CertificationTask object has keys "name" and "index", where "index" is an integer task offset and "name" is either one of a fixed list of known strings (e.g. "unit-tests" or "standard-property") or an object with key "unknown-name" set equal to the default Haskell rendering of the unknown task name.