### PR TITLE
feat: get logs for a Cicero Run

### DIFF
--- a/nix/materialized/aarch64-darwin/.plan.nix/plutus-certification.nix
+++ b/nix/materialized/aarch64-darwin/.plan.nix/plutus-certification.nix
@@ -54,6 +54,7 @@
           (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
           (hsPkgs."eventuo11y" or (errorHandler.buildDepError "eventuo11y"))
           (hsPkgs."eventuo11y-batteries" or (errorHandler.buildDepError "eventuo11y-batteries"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
           (hsPkgs."dapps-certification-interface" or (errorHandler.buildDepError "dapps-certification-interface"))
@@ -111,6 +112,8 @@
             (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
             (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."plutus-certification" or (errorHandler.buildDepError "plutus-certification"))
             ];
           buildable = true;

--- a/nix/materialized/x86_64-darwin/.plan.nix/plutus-certification.nix
+++ b/nix/materialized/x86_64-darwin/.plan.nix/plutus-certification.nix
@@ -54,6 +54,7 @@
           (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
           (hsPkgs."eventuo11y" or (errorHandler.buildDepError "eventuo11y"))
           (hsPkgs."eventuo11y-batteries" or (errorHandler.buildDepError "eventuo11y-batteries"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
           (hsPkgs."dapps-certification-interface" or (errorHandler.buildDepError "dapps-certification-interface"))
@@ -111,6 +112,8 @@
             (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
             (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."plutus-certification" or (errorHandler.buildDepError "plutus-certification"))
             ];
           buildable = true;

--- a/nix/materialized/x86_64-linux/.plan.nix/plutus-certification.nix
+++ b/nix/materialized/x86_64-linux/.plan.nix/plutus-certification.nix
@@ -54,6 +54,7 @@
           (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
           (hsPkgs."eventuo11y" or (errorHandler.buildDepError "eventuo11y"))
           (hsPkgs."eventuo11y-batteries" or (errorHandler.buildDepError "eventuo11y-batteries"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
           (hsPkgs."dapps-certification-interface" or (errorHandler.buildDepError "dapps-certification-interface"))
@@ -111,6 +112,8 @@
             (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
             (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."plutus-certification" or (errorHandler.buildDepError "plutus-certification"))
             ];
           buildable = true;

--- a/plutus-certification.cabal
+++ b/plutus-certification.cabal
@@ -40,6 +40,7 @@ library
     exceptions ^>= 0.10.4,
     eventuo11y ^>= 0.3.2,
     eventuo11y-batteries ^>= 0.2.1,
+    time ^>= 1.11.1.1,
     filepath,
     temporary,
     dapps-certification-interface,
@@ -95,6 +96,8 @@ executable plutus-certification-client
     uuid ^>= 1.3.15,
     network-uri ^>= 2.6.4.1,
     aeson ^>= 2.0.3.0,
+    time ^>= 1.11.1.1,
+    text ^>= 1.2.5.0,
     plutus-certification
   main-is: Main.hs
   hs-source-dirs: client

--- a/src/Plutus/Certification/Local.hs
+++ b/src/Plutus/Certification/Local.hs
@@ -98,6 +98,9 @@ localServerCaps backend = do
      readIORef cancellations >>= sequence_ . Map.lookup jobId
      freeCancellation jobId
 
+    -- TODO: implement for Local also
+    getLogs = \_ _ _ -> yieldMany []
+
   pure $ ServerCaps {..}
 
 data LocalSelector f where


### PR DESCRIPTION
add functionality for getting the logs Cicero

There are some things to be addressed

- getting logs in `--local` mode
- there are some serialization issues when `ZonedTime` is passed through the servant client (CLI)
- the implementation assumes there are maximum 3 distinct jobs for a Run (generate, build and certify)
- fetching the logs entirely from Cicero, might not be the best approach 

I'm sending this PR first because Front End needs a deployment instance to be unblocked