### PR TITLE
feat: persistence (DAC-358 , DAC-359, DAC-362, DAC-382)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ flake
 gentags.sh
 tags
 docker/
+Makefile
+*.sqlite

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,5 @@
 index-state: 2022-10-13T00:00:00Z
-packages: . dapps-certification-interface dapps-certification-helpers
-
+packages: . dapps-certification-interface dapps-certification-helpers dapps-certification-persistence
 package plutus-certification
   ghc-options: -Wall
 
@@ -8,6 +7,9 @@ package dapps-certification-interface
   ghc-options: -Wall
 
 package dapps-certification-helpers
+  ghc-options: -Wall
+
+package dapps-certification-persistence
   ghc-options: -Wall
 
 write-ghc-environment-files: never

--- a/dapps-certification-persistence/dapps-certification-persistence.cabal
+++ b/dapps-certification-persistence/dapps-certification-persistence.cabal
@@ -1,0 +1,20 @@
+cabal-version:      2.4
+name:               dapps-certification-persistence
+version:            0.1.0.0
+author:             Bogdan Manole
+maintainer:         bogdan.manole@iohk.io
+
+library
+    exposed-modules:  IOHK.Certification.Persistence
+    other-modules:    IOHK.Certification.Persistence.Structure
+                    , IOHK.Certification.Persistence.API
+    build-depends: base
+                 , selda
+                 , selda-sqlite
+                 , selda-postgresql
+                 , uuid
+                 , text
+                 , time
+                 , aeson
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
@@ -1,0 +1,28 @@
+module IOHK.Certification.Persistence (module X) where
+
+import IOHK.Certification.Persistence.Structure as X
+  ( Run(..)
+  , Status(..)
+  , Contact(..)
+  , Author(..)
+  , Profile(..)
+  , profiles
+  , runs
+  , authors
+  , contacts
+  , createTables
+  , ProfileId
+  )
+import IOHK.Certification.Persistence.API as X
+  ( upsertProfile
+  , getProfile
+  , createRun
+  , updateFinishedRun
+  , updateCertificateCreation
+  , getRuns
+  , withDb
+  , getProfileId
+  , getProfileAddress
+  , syncRun
+  , getRunOwner
+  )

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence/API.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence/API.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module IOHK.Certification.Persistence.API where
+
+import Database.Selda
+import Database.Selda.SQLite
+import IOHK.Certification.Persistence.Structure
+import Data.Maybe
+import Control.Monad
+
+upsertProfile :: (MonadSelda m, MonadMask m) => Profile -> m (Maybe (ID Profile))
+upsertProfile arg@Profile{..} = do
+  upsert profiles
+     (\profile -> profile ! #ownerAddress .== text ownerAddress)
+     (`with`
+      [ #dapp     := fromTextMaybe dapp -- TODO: don't know if we should update the dapp
+      , #website  := fromTextMaybe website
+      , #vendor   := fromTextMaybe vendor
+      , #twitter  := fromTextMaybe twitter
+      , #linkedin := fromTextMaybe linkedin
+      --TODO: authors and contacts
+      ])
+     [#profileId (def :: ID Profile) arg]
+  where
+  fromTextMaybe = maybe null_ (just . text)
+
+getProfileByAddress :: MonadSelda m => Text -> m (Maybe Profile)
+getProfileByAddress address = listToMaybe <$> (query $ do
+    p <- select profiles
+    restrict (p ! #ownerAddress .== text address)
+    pure p
+  )
+
+getProfileQ :: ID Profile -> Query t (Row t Profile)
+getProfileQ pid = do
+    p <- select profiles
+    restrict (p ! #profileId .== literal pid )
+    pure p
+
+getProfile :: MonadSelda m => ID Profile -> m (Maybe Profile)
+getProfile = fmap listToMaybe . query . getProfileQ
+
+
+getProfileIdQ:: Text -> Query t (Col t (ID Profile))
+getProfileIdQ  address = do
+  p <- select profiles
+  restrict (p ! #ownerAddress .== text address)
+  pure (p ! #profileId)
+
+getProfileId :: MonadSelda m => Text -> m (Maybe ProfileId)
+getProfileId = fmap listToMaybe . query . getProfileIdQ
+
+getProfileAddressQ :: ID Profile -> Query t (Col t Text)
+getProfileAddressQ  pid = do
+  p <- select profiles
+  restrict (p ! #profileId .== literal pid)
+  pure (p ! #ownerAddress)
+
+getProfileAddress :: MonadSelda m => ID Profile -> m (Maybe Text)
+getProfileAddress = fmap listToMaybe . query . getProfileAddressQ
+
+createRun :: MonadSelda m => UUID -> UTCTime -> Text -> UTCTime -> ID Profile -> m ()
+createRun runId time repo commitDate pid = do
+  void $ insert runs [Run runId time (Just time) time repo commitDate Queued pid Nothing]
+
+getRunOwnerQ :: UUID -> Query t (Col t (ID Profile))
+getRunOwnerQ runId = do
+    p <- select runs
+    restrict (p ! #runId .== literal runId )
+    pure (p ! #profileId)
+
+getRunOwner :: MonadSelda m => UUID -> m (Maybe (ID Profile))
+getRunOwner = fmap listToMaybe . query . getRunOwnerQ
+
+updateFinishedRun :: MonadSelda m => UUID -> Bool -> UTCTime -> m Int
+updateFinishedRun runId succeeded time= do
+  update runs
+    (\run -> (run ! #runId .== literal runId) .&& (run ! #runStatus .== literal Queued))
+    (`with`
+      [ #runStatus := literal (if succeeded then Succeeded else Failed)
+      , #syncedAt := literal time
+      , #finishedAt := literal (Just time)
+      ]
+    )
+
+syncRun :: MonadSelda m => UUID ->  UTCTime -> m Int
+syncRun runId time= update runs
+    (\run -> (run ! #runId .== literal runId))
+    (`with` [ #syncedAt := literal time ])
+
+updateCertificateCreation :: MonadSelda m => ID Profile -> UTCTime -> m Int
+updateCertificateCreation pid time= update runs
+      (\run -> (run ! #profileId .== literal pid) .&& (run ! #runStatus .== literal Succeeded))
+      (`with` [ #certificateCreatedAt := literal (Just time) ] )
+
+getRuns :: MonadSelda m => ID Profile -> Maybe UTCTime -> Maybe Int -> m [Run]
+getRuns pid afterM topM = query $
+  case topM of
+    Just top -> limit 0 top select'
+    Nothing -> select runs
+  where
+  select' = do
+    run <- select runs
+    restrict (run ! #profileId .== literal pid)
+    case afterM of
+      Just after -> restrict (run ! #created .< literal after)
+      Nothing -> pure ()
+    order (run ! #created) descending
+    pure run
+
+--TODO: replace this with a proper configuration
+withDb :: (MonadIO m, MonadMask m) => SeldaT SQLite m a -> m a
+withDb = withSQLite "people.sqlite"

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence/Structure.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence/Structure.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module IOHK.Certification.Persistence.Structure where
+
+import Database.Selda
+import GHC.OverloadedLabels
+import Data.Aeson
+
+data Profile = Profile
+  { profileId :: ID Profile -- TODO: do we need an internal id?
+  , ownerAddress :: Text    -- TODO: type level restrictions might apply in the future
+                            -- regarding the format
+  , dapp :: Maybe Text
+  , website :: Maybe Text
+  , vendor :: Maybe Text
+  , twitter :: Maybe Text
+  , linkedin :: Maybe Text
+  } deriving (Generic, Show)
+
+type ProfileId = ID Profile
+
+instance FromJSON Profile where
+    parseJSON = withObject "Profile" $ \v -> Profile
+      <$> (pure def)
+      <*> v .: "address"
+      <*> v .:? "dapp"  .!= Nothing
+      <*> v .:? "website"  .!= Nothing
+      <*> v .:? "vendor"  .!= Nothing
+      <*> v .:? "twitter"  .!= Nothing
+      <*> v .:? "linkedin"  .!= Nothing
+
+instance ToJSON Profile where
+  toJSON (Profile{..}) = object
+      [ "address" .= ownerAddress
+      , "dapp" .= dapp
+      , "website" .= website
+      , "vendor" .= vendor
+      , "twitter" .= twitter
+      , "linkedin" .= linkedin
+      ]
+instance SqlRow Profile
+
+data Author = Author
+  { authorId :: ID Author
+  , name :: Text
+  , profileId :: ID Profile
+  } deriving (Generic,Show)
+
+instance SqlRow Author
+
+instance IsLabel "profileId" (ID Profile -> Author -> Author) where
+  fromLabel = \v p -> p { profileId = v}
+
+data Contact = Contact
+  { contactId :: ID Contact
+  , name :: Text
+  , details :: Maybe Text
+  , profileId :: ID Profile
+  } deriving (Generic,Show)
+
+instance IsLabel "profileId" (ID Profile -> Contact -> Contact) where
+  fromLabel = \v p -> p { profileId = v}
+
+instance SqlRow Contact
+
+data Status = Queued | Failed | Succeeded
+  deriving (Show, Read, Bounded, Enum, Eq)
+
+instance ToJSON Status where
+  toJSON :: Status -> Value
+  toJSON Queued = toJSON ("queued" :: Text)
+  toJSON Failed = toJSON ("failed" :: Text)
+  toJSON Succeeded = toJSON ("succeeded" :: Text)
+
+instance FromJSON Status where
+    parseJSON =
+      withText "Status" handle
+      where
+        handle "queued" = pure Queued
+        handle "failed" = pure Failed
+        handle "succeeded" = pure Succeeded
+        handle t = fail $ "provided text (" ++ show t ++ ") is not a Status"
+
+instance SqlType Status
+
+data Run = Run
+  { runId :: UUID
+  , created :: UTCTime
+  , finishedAt :: Maybe UTCTime
+  , syncedAt :: UTCTime
+  , repoUrl :: Text
+  , commitDate :: UTCTime
+  , runStatus :: Status
+  , profileId :: ID Profile
+  , certificateCreatedAt :: Maybe UTCTime
+  } deriving (Generic,Show)
+
+instance ToJSON Run where
+  toJSON (Run{..}) = object
+      [ "runId" .= runId
+      , "created" .= created
+      , "finishedAt" .= finishedAt
+      , "syncedAt" .= syncedAt
+      , "repoUrl" .= repoUrl
+      , "commitDate" .= commitDate
+      , "runStatus" .= runStatus
+      , "certificateCreatedAt" .= certificateCreatedAt
+      ]
+
+instance FromJSON Run where
+    parseJSON = withObject "Run" $ \v -> Run
+        <$> v .: "runId"
+        <*> v .: "created"
+        <*> v .:? "finishedAt" .!= Nothing
+        <*> v .: "syncedAt"
+        <*> v .: "repoUrl"
+        <*> v .: "commitDate"
+        <*> v .: "runStatus"
+        <*> (pure def)
+        <*> v .:? "certificateCreatedAt" .!= Nothing
+
+instance SqlRow Run
+
+instance IsLabel "profileId" (ID Profile -> Profile -> Profile) where
+  fromLabel = \v p -> p { profileId = v}
+
+profiles :: Table Profile
+profiles = table "profile"
+  [ #profileId :- autoPrimary
+  , #ownerAddress :- unique
+  , #ownerAddress :- index
+  ]
+
+runs :: Table Run
+runs = table "run"
+  [ #runId :- primary
+  , #profileId :- foreignKey profiles #profileId
+  , #created :- index
+  ]
+
+authors :: Table Author
+authors = table "author"
+  [ #authorId :- primary
+  , #profileId :- foreignKey profiles #profileId
+  ]
+
+contacts :: Table Contact
+contacts = table "contact"
+  [ #contactId :- primary
+  , #profileId :- foreignKey profiles #profileId
+  ]
+
+
+createTables :: MonadSelda m => m ()
+createTables = do
+  createTable profiles
+  createTable authors
+  createTable contacts
+  createTable runs
+
+
+

--- a/nix/materialized/aarch64-darwin/.plan.nix/dapps-certification-persistence.nix
+++ b/nix/materialized/aarch64-darwin/.plan.nix/dapps-certification-persistence.nix
@@ -1,0 +1,58 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = {
+        name = "dapps-certification-persistence";
+        version = "0.1.0.0";
+        };
+      license = "NONE";
+      copyright = "";
+      maintainer = "bogdan.manole@iohk.io";
+      author = "Bogdan Manole";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."selda" or (errorHandler.buildDepError "selda"))
+          (hsPkgs."selda-sqlite" or (errorHandler.buildDepError "selda-sqlite"))
+          (hsPkgs."selda-postgresql" or (errorHandler.buildDepError "selda-postgresql"))
+          (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          ];
+        buildable = true;
+        modules = [
+          "IOHK/Certification/Persistence/Structure"
+          "IOHK/Certification/Persistence/API"
+          "IOHK/Certification/Persistence/DummyState"
+          "IOHK/Certification/Persistence"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../dapps-certification-persistence; }

--- a/nix/materialized/aarch64-darwin/.plan.nix/plutus-certification.nix
+++ b/nix/materialized/aarch64-darwin/.plan.nix/plutus-certification.nix
@@ -57,6 +57,7 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
+          (hsPkgs."dapps-certification-persistence" or (errorHandler.buildDepError "dapps-certification-persistence"))
           (hsPkgs."dapps-certification-interface" or (errorHandler.buildDepError "dapps-certification-interface"))
           (hsPkgs."dapps-certification-helpers" or (errorHandler.buildDepError "dapps-certification-helpers"))
           ];
@@ -93,6 +94,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."plutus-certification" or (errorHandler.buildDepError "plutus-certification"))
+            (hsPkgs."dapps-certification-persistence" or (errorHandler.buildDepError "dapps-certification-persistence"))
             ];
           buildable = true;
           modules = [ "Paths_plutus_certification" ];

--- a/nix/materialized/aarch64-darwin/default.nix
+++ b/nix/materialized/aarch64-darwin/default.nix
@@ -2,15 +2,22 @@
   pkgs = hackage:
     {
       packages = {
+        "charset".revision = (((hackage."charset")."0.3.9").revisions).default;
         "old-time".revision = (((hackage."old-time")."1.1.0.3").revisions).default;
         "servant-client".revision = (((hackage."servant-client")."0.19").revisions).default;
         "mmorph".revision = (((hackage."mmorph")."1.2.0").revisions).default;
+        "postgresql-binary".revision = (((hackage."postgresql-binary")."0.12.5").revisions).default;
         "happy".revision = (((hackage."happy")."1.20.0").revisions).default;
         "streaming-commons".revision = (((hackage."streaming-commons")."0.2.2.4").revisions).default;
         "streaming-commons".flags.use-bytestring-builder = false;
         "pretty".revision = (((hackage."pretty")."1.1.3.6").revisions).default;
         "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
+        "data-textual".revision = (((hackage."data-textual")."0.3.0.3").revisions).default;
         "network-uri".revision = (((hackage."network-uri")."2.6.4.1").revisions).default;
+        "parsers".revision = (((hackage."parsers")."0.12.11").revisions).default;
+        "parsers".flags.parsec = true;
+        "parsers".flags.binary = true;
+        "parsers".flags.attoparsec = true;
         "unordered-containers".revision = (((hackage."unordered-containers")."0.2.19.1").revisions).default;
         "unordered-containers".flags.debug = false;
         "integer-logarithms".revision = (((hackage."integer-logarithms")."1.0.3.1").revisions).default;
@@ -54,6 +61,7 @@
         "some".revision = (((hackage."some")."1.0.4.1").revisions).default;
         "some".flags.newtype-unsafe = true;
         "temporary".revision = (((hackage."temporary")."1.3").revisions).default;
+        "selda".revision = (((hackage."selda")."0.5.2.0").revisions).default;
         "comonad".revision = (((hackage."comonad")."5.0.8").revisions).default;
         "comonad".flags.containers = true;
         "comonad".flags.distributive = true;
@@ -65,28 +73,35 @@
         "asn1-types".revision = (((hackage."asn1-types")."0.3.4").revisions).default;
         "base-compat".revision = (((hackage."base-compat")."0.12.2").revisions).default;
         "string-conversions".revision = (((hackage."string-conversions")."0.4.0.1").revisions).default;
+        "data-endian".revision = (((hackage."data-endian")."0.1.1").revisions).default;
         "bitvec".revision = (((hackage."bitvec")."1.1.3.0").revisions).default;
         "bitvec".flags.libgmp = false;
         "contravariant".revision = (((hackage."contravariant")."1.5.5").revisions).default;
         "contravariant".flags.tagged = true;
         "contravariant".flags.semigroups = true;
         "contravariant".flags.statevar = true;
+        "type-hint".revision = (((hackage."type-hint")."0.1").revisions).default;
         "base-compat-batteries".revision = (((hackage."base-compat-batteries")."0.12.2").revisions).default;
         "safe".revision = (((hackage."safe")."0.3.19").revisions).default;
         "Cabal".revision = (((hackage."Cabal")."3.6.3.0").revisions).default;
         "sop-core".revision = (((hackage."sop-core")."0.5.0.2").revisions).default;
         "assoc".revision = (((hackage."assoc")."1.0.2").revisions).default;
         "cicero-api".revision = (((hackage."cicero-api")."0.1.2.0").revisions).default;
+        "binary-parser".revision = (((hackage."binary-parser")."0.5.7.2").revisions).default;
         "unliftio".revision = (((hackage."unliftio")."0.2.22.0").revisions).default;
         "data-fix".revision = (((hackage."data-fix")."0.3.2").revisions).default;
         "tls".revision = (((hackage."tls")."1.6.0").revisions).default;
         "tls".flags.network = true;
         "tls".flags.hans = false;
         "tls".flags.compat = true;
+        "text-printer".revision = (((hackage."text-printer")."0.5.0.2").revisions).default;
         "http-client-tls".revision = (((hackage."http-client-tls")."0.3.6.1").revisions).default;
+        "data-bword".revision = (((hackage."data-bword")."0.1.0.2").revisions).default;
         "basement".revision = (((hackage."basement")."0.0.15").revisions).default;
+        "network-ip".revision = (((hackage."network-ip")."0.3.0.3").revisions).default;
         "old-locale".revision = (((hackage."old-locale")."1.0.0.7").revisions).default;
         "mtl".revision = (((hackage."mtl")."2.2.2").revisions).default;
+        "selda-json".revision = (((hackage."selda-json")."0.1.1.1").revisions).default;
         "OneTuple".revision = (((hackage."OneTuple")."0.3.1").revisions).default;
         "mime-types".revision = (((hackage."mime-types")."0.1.1.0").revisions).default;
         "parsec".revision = (((hackage."parsec")."3.1.15.0").revisions).default;
@@ -94,6 +109,7 @@
         "attoparsec-iso8601".revision = (((hackage."attoparsec-iso8601")."1.0.2.1").revisions).default;
         "attoparsec-iso8601".flags.fast = false;
         "attoparsec-iso8601".flags.developer = false;
+        "data-dword".revision = (((hackage."data-dword")."0.3.2.1").revisions).default;
         "pem".revision = (((hackage."pem")."0.2.4").revisions).default;
         "strict".revision = (((hackage."strict")."0.4.0.1").revisions).default;
         "strict".flags.assoc = true;
@@ -111,10 +127,13 @@
         "splitmix".flags.optimised-mixer = false;
         "recv".revision = (((hackage."recv")."0.0.0").revisions).default;
         "file-embed".revision = (((hackage."file-embed")."0.0.15.0").revisions).default;
+        "text-latin1".revision = (((hackage."text-latin1")."0.3.1").revisions).default;
         "attoparsec".revision = (((hackage."attoparsec")."0.14.4").revisions).default;
         "attoparsec".flags.developer = false;
+        "bytestring-strict-builder".revision = (((hackage."bytestring-strict-builder")."0.4.5.6").revisions).default;
         "singleton-bool".revision = (((hackage."singleton-bool")."0.1.6").revisions).default;
         "th-compat".revision = (((hackage."th-compat")."0.1.4").revisions).default;
+        "data-checked".revision = (((hackage."data-checked")."0.3").revisions).default;
         "memory".revision = (((hackage."memory")."0.18.0").revisions).default;
         "memory".flags.support_deepseq = true;
         "memory".flags.support_bytestring = true;
@@ -140,6 +159,8 @@
         "free".revision = (((hackage."free")."5.1.9").revisions).default;
         "terminfo".revision = (((hackage."terminfo")."0.4.1.5").revisions).default;
         "connection".revision = (((hackage."connection")."0.3.1").revisions).default;
+        "postgresql-libpq".revision = (((hackage."postgresql-libpq")."0.9.4.3").revisions).default;
+        "postgresql-libpq".flags.use-pkg-config = false;
         "resourcet".revision = (((hackage."resourcet")."1.2.6").revisions).default;
         "vault".revision = (((hackage."vault")."0.3.1.5").revisions).default;
         "vault".flags.useghc = true;
@@ -162,6 +183,8 @@
         "vector-stream".revision = (((hackage."vector-stream")."0.1.0.0").revisions).default;
         "ghc-boot-th".revision = (((hackage."ghc-boot-th")."9.2.4").revisions).default;
         "asn1-encoding".revision = (((hackage."asn1-encoding")."0.9.6").revisions).default;
+        "selda-postgresql".revision = (((hackage."selda-postgresql")."0.1.8.2").revisions).default;
+        "selda-postgresql".flags.haste = false;
         "indexed-traversable".revision = (((hackage."indexed-traversable")."0.1.2").revisions).default;
         "distributive".revision = (((hackage."distributive")."0.6.2.1").revisions).default;
         "distributive".flags.tagged = true;
@@ -169,6 +192,7 @@
         "text-short".revision = (((hackage."text-short")."0.1.5").revisions).default;
         "text-short".flags.asserts = false;
         "servant".revision = (((hackage."servant")."0.19").revisions).default;
+        "data-serializer".revision = (((hackage."data-serializer")."0.3.5").revisions).default;
         "bsb-http-chunked".revision = (((hackage."bsb-http-chunked")."0.0.0.4").revisions).default;
         "bifunctors".revision = (((hackage."bifunctors")."5.5.13").revisions).default;
         "bifunctors".flags.tagged = true;
@@ -218,6 +242,8 @@
         "base-unicode-symbols".flags.base-4-8 = true;
         "base-unicode-symbols".flags.old-base = false;
         "wai-logger".revision = (((hackage."wai-logger")."2.4.0").revisions).default;
+        "selda-sqlite".revision = (((hackage."selda-sqlite")."0.1.7.2").revisions).default;
+        "selda-sqlite".flags.haste = false;
         "these".revision = (((hackage."these")."1.1.1.1").revisions).default;
         "these".flags.assoc = true;
         "split".revision = (((hackage."split")."0.2.3.5").revisions).default;
@@ -251,6 +277,12 @@
         "wai-app-static".flags.print = false;
         "transformers".revision = (((hackage."transformers")."0.5.6.2").revisions).default;
         "template-haskell".revision = (((hackage."template-haskell")."2.18.0.0").revisions).default;
+        "direct-sqlite".revision = (((hackage."direct-sqlite")."2.3.27").revisions).default;
+        "direct-sqlite".flags.haveusleep = true;
+        "direct-sqlite".flags.systemlib = false;
+        "direct-sqlite".flags.fulltextsearch = true;
+        "direct-sqlite".flags.urifilenames = true;
+        "direct-sqlite".flags.json1 = true;
         "blaze-markup".revision = (((hackage."blaze-markup")."0.8.2.8").revisions).default;
         "mono-traversable".revision = (((hackage."mono-traversable")."1.0.15.3").revisions).default;
         "witherable".revision = (((hackage."witherable")."0.4.2").revisions).default;
@@ -349,6 +381,7 @@
       packages = {
         dapps-certification-interface = ./.plan.nix/dapps-certification-interface.nix;
         dapps-certification-helpers = ./.plan.nix/dapps-certification-helpers.nix;
+        dapps-certification-persistence = ./.plan.nix/dapps-certification-persistence.nix;
         plutus-certification = ./.plan.nix/plutus-certification.nix;
         };
       };
@@ -358,6 +391,7 @@
         packages = {
           "dapps-certification-interface" = { flags = {}; };
           "dapps-certification-helpers" = { flags = {}; };
+          "dapps-certification-persistence" = { flags = {}; };
           "plutus-certification" = { flags = {}; };
           };
         })
@@ -376,11 +410,13 @@
           "cookie".components.library.planned = lib.mkOverride 900 true;
           "these".components.library.planned = lib.mkOverride 900 true;
           "cereal".components.library.planned = lib.mkOverride 900 true;
+          "selda".components.library.planned = lib.mkOverride 900 true;
           "resourcet".components.library.planned = lib.mkOverride 900 true;
           "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "http2".components.library.planned = lib.mkOverride 900 true;
           "filepath".components.library.planned = lib.mkOverride 900 true;
           "wai".components.library.planned = lib.mkOverride 900 true;
+          "data-textual".components.library.planned = lib.mkOverride 900 true;
           "distributive".components.library.planned = lib.mkOverride 900 true;
           "pretty".components.library.planned = lib.mkOverride 900 true;
           "utf8-string".components.library.planned = lib.mkOverride 900 true;
@@ -391,7 +427,9 @@
           "mono-traversable".components.library.planned = lib.mkOverride 900 true;
           "zlib".components.library.planned = lib.mkOverride 900 true;
           "servant-server".components.exes."greet".planned = lib.mkOverride 900 true;
+          "data-dword".components.library.planned = lib.mkOverride 900 true;
           "strict".components.library.planned = lib.mkOverride 900 true;
+          "text-printer".components.library.planned = lib.mkOverride 900 true;
           "entropy".components.setup.planned = lib.mkOverride 900 true;
           "comonad".components.library.planned = lib.mkOverride 900 true;
           "data-fix".components.library.planned = lib.mkOverride 900 true;
@@ -407,6 +445,7 @@
           "dlist".components.library.planned = lib.mkOverride 900 true;
           "time-manager".components.library.planned = lib.mkOverride 900 true;
           "ghc-prim".components.library.planned = lib.mkOverride 900 true;
+          "postgresql-libpq".components.setup.planned = lib.mkOverride 900 true;
           "HUnit".components.library.planned = lib.mkOverride 900 true;
           "some".components.library.planned = lib.mkOverride 900 true;
           "array".components.library.planned = lib.mkOverride 900 true;
@@ -415,6 +454,7 @@
           "cicero-api".components.exes."cicero-cli".planned = lib.mkOverride 900 true;
           "dapps-certification-helpers".components.library.planned = lib.mkOverride 900 true;
           "binary".components.library.planned = lib.mkOverride 900 true;
+          "charset".components.library.planned = lib.mkOverride 900 true;
           "wai-extra".components.library.planned = lib.mkOverride 900 true;
           "ghc-boot-th".components.library.planned = lib.mkOverride 900 true;
           "scientific".components.library.planned = lib.mkOverride 900 true;
@@ -434,6 +474,7 @@
           "indexed-traversable-instances".components.library.planned = lib.mkOverride 900 true;
           "servant-server".components.library.planned = lib.mkOverride 900 true;
           "data-default-class".components.library.planned = lib.mkOverride 900 true;
+          "type-hint".components.library.planned = lib.mkOverride 900 true;
           "adjunctions".components.library.planned = lib.mkOverride 900 true;
           "cryptonite".components.library.planned = lib.mkOverride 900 true;
           "asn1-parse".components.library.planned = lib.mkOverride 900 true;
@@ -441,6 +482,7 @@
           "network-byte-order".components.library.planned = lib.mkOverride 900 true;
           "mime-types".components.library.planned = lib.mkOverride 900 true;
           "directory".components.library.planned = lib.mkOverride 900 true;
+          "network-ip".components.library.planned = lib.mkOverride 900 true;
           "happy".components.exes."happy".planned = lib.mkOverride 900 true;
           "network-info".components.library.planned = lib.mkOverride 900 true;
           "uuid".components.library.planned = lib.mkOverride 900 true;
@@ -458,6 +500,7 @@
           "haskeline".components.library.planned = lib.mkOverride 900 true;
           "th-expand-syns".components.library.planned = lib.mkOverride 900 true;
           "unix-time".components.library.planned = lib.mkOverride 900 true;
+          "direct-sqlite".components.library.planned = lib.mkOverride 900 true;
           "cryptohash-sha1".components.library.planned = lib.mkOverride 900 true;
           "free".components.library.planned = lib.mkOverride 900 true;
           "unix-compat".components.library.planned = lib.mkOverride 900 true;
@@ -473,6 +516,7 @@
           "indexed-traversable".components.library.planned = lib.mkOverride 900 true;
           "network-uri".components.library.planned = lib.mkOverride 900 true;
           "wai-logger".components.setup.planned = lib.mkOverride 900 true;
+          "data-serializer".components.library.planned = lib.mkOverride 900 true;
           "memory".components.library.planned = lib.mkOverride 900 true;
           "pem".components.library.planned = lib.mkOverride 900 true;
           "typed-process".components.library.planned = lib.mkOverride 900 true;
@@ -486,11 +530,14 @@
           "entropy".components.library.planned = lib.mkOverride 900 true;
           "assoc".components.library.planned = lib.mkOverride 900 true;
           "process".components.library.planned = lib.mkOverride 900 true;
+          "binary-parser".components.library.planned = lib.mkOverride 900 true;
+          "selda-postgresql".components.library.planned = lib.mkOverride 900 true;
           "http-date".components.library.planned = lib.mkOverride 900 true;
           "template-haskell".components.library.planned = lib.mkOverride 900 true;
           "blaze-markup".components.library.planned = lib.mkOverride 900 true;
           "th-lift".components.library.planned = lib.mkOverride 900 true;
           "stm".components.library.planned = lib.mkOverride 900 true;
+          "postgresql-binary".components.library.planned = lib.mkOverride 900 true;
           "byteorder".components.library.planned = lib.mkOverride 900 true;
           "witherable".components.library.planned = lib.mkOverride 900 true;
           "plutus-certification".components.library.planned = lib.mkOverride 900 true;
@@ -503,32 +550,40 @@
           "cabal-doctest".components.library.planned = lib.mkOverride 900 true;
           "iproute".components.library.planned = lib.mkOverride 900 true;
           "servant-client".components.library.planned = lib.mkOverride 900 true;
+          "selda-sqlite".components.library.planned = lib.mkOverride 900 true;
           "wai-logger".components.library.planned = lib.mkOverride 900 true;
           "th-compat".components.library.planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
+          "bytestring-strict-builder".components.library.planned = lib.mkOverride 900 true;
           "http-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
           "ansi-wl-pprint".components.library.planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "semigroupoids".components.library.planned = lib.mkOverride 900 true;
           "x509-validation".components.library.planned = lib.mkOverride 900 true;
+          "postgresql-libpq".components.library.planned = lib.mkOverride 900 true;
           "dapps-certification-helpers".components.exes."build-flake".planned = lib.mkOverride 900 true;
           "wai-app-static".components.exes."warp".planned = lib.mkOverride 900 true;
           "singleton-bool".components.library.planned = lib.mkOverride 900 true;
           "attoparsec".components.library.planned = lib.mkOverride 900 true;
+          "data-checked".components.library.planned = lib.mkOverride 900 true;
+          "dapps-certification-persistence".components.library.planned = lib.mkOverride 900 true;
           "mtl".components.library.planned = lib.mkOverride 900 true;
           "base-unicode-symbols".components.library.planned = lib.mkOverride 900 true;
           "aeson-qq".components.library.planned = lib.mkOverride 900 true;
           "vault".components.library.planned = lib.mkOverride 900 true;
           "th-abstraction".components.library.planned = lib.mkOverride 900 true;
           "attoparsec".components.sublibs."attoparsec-internal".planned = lib.mkOverride 900 true;
+          "parsers".components.library.planned = lib.mkOverride 900 true;
           "transformers".components.library.planned = lib.mkOverride 900 true;
           "wai-app-static".components.library.planned = lib.mkOverride 900 true;
+          "selda-json".components.library.planned = lib.mkOverride 900 true;
           "conduit-aeson".components.library.planned = lib.mkOverride 900 true;
           "OneTuple".components.library.planned = lib.mkOverride 900 true;
           "parsec".components.library.planned = lib.mkOverride 900 true;
           "deepseq".components.library.planned = lib.mkOverride 900 true;
           "primitive".components.library.planned = lib.mkOverride 900 true;
+          "text-latin1".components.library.planned = lib.mkOverride 900 true;
           "old-locale".components.library.planned = lib.mkOverride 900 true;
           "conduit".components.library.planned = lib.mkOverride 900 true;
           "eventuo11y".components.library.planned = lib.mkOverride 900 true;
@@ -551,6 +606,7 @@
           "th-reify-many".components.library.planned = lib.mkOverride 900 true;
           "dapps-certification-helpers".components.exes."generate-flake".planned = lib.mkOverride 900 true;
           "time-compat".components.library.planned = lib.mkOverride 900 true;
+          "data-endian".components.library.planned = lib.mkOverride 900 true;
           "basement".components.library.planned = lib.mkOverride 900 true;
           "optparse-applicative".components.library.planned = lib.mkOverride 900 true;
           "wai-cors".components.library.planned = lib.mkOverride 900 true;
@@ -558,6 +614,7 @@
           "x509-system".components.library.planned = lib.mkOverride 900 true;
           "hourglass".components.library.planned = lib.mkOverride 900 true;
           "base-compat".components.library.planned = lib.mkOverride 900 true;
+          "data-bword".components.library.planned = lib.mkOverride 900 true;
           "base64-bytestring".components.library.planned = lib.mkOverride 900 true;
           "hashable".components.library.planned = lib.mkOverride 900 true;
           "semigroups".components.library.planned = lib.mkOverride 900 true;

--- a/nix/materialized/x86_64-darwin/.plan.nix/dapps-certification-persistence.nix
+++ b/nix/materialized/x86_64-darwin/.plan.nix/dapps-certification-persistence.nix
@@ -1,0 +1,57 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = {
+        name = "dapps-certification-persistence";
+        version = "0.1.0.0";
+        };
+      license = "NONE";
+      copyright = "";
+      maintainer = "bogdan.manole@iohk.io";
+      author = "Bogdan Manole";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."selda" or (errorHandler.buildDepError "selda"))
+          (hsPkgs."selda-sqlite" or (errorHandler.buildDepError "selda-sqlite"))
+          (hsPkgs."selda-postgresql" or (errorHandler.buildDepError "selda-postgresql"))
+          (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          ];
+        buildable = true;
+        modules = [
+          "IOHK/Certification/Persistence/Structure"
+          "IOHK/Certification/Persistence/API"
+          "IOHK/Certification/Persistence"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../dapps-certification-persistence; }

--- a/nix/materialized/x86_64-darwin/.plan.nix/plutus-certification.nix
+++ b/nix/materialized/x86_64-darwin/.plan.nix/plutus-certification.nix
@@ -35,12 +35,12 @@
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."cicero-api" or (errorHandler.buildDepError "cicero-api"))
           (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
           (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
           (hsPkgs."servant-client-core" or (errorHandler.buildDepError "servant-client-core"))
           (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
           (hsPkgs."conduit" or (errorHandler.buildDepError "conduit"))
-          (hsPkgs."cicero-api" or (errorHandler.buildDepError "cicero-api"))
           (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
@@ -57,6 +57,7 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
+          (hsPkgs."dapps-certification-persistence" or (errorHandler.buildDepError "dapps-certification-persistence"))
           (hsPkgs."dapps-certification-interface" or (errorHandler.buildDepError "dapps-certification-interface"))
           (hsPkgs."dapps-certification-helpers" or (errorHandler.buildDepError "dapps-certification-helpers"))
           ];
@@ -69,6 +70,7 @@
           "Plutus/Certification/Client"
           "Plutus/Certification/Server"
           "Plutus/Certification/Local"
+          "Plutus/Certification/GithubClient"
           ];
         hsSourceDirs = [ "src" ];
         };
@@ -93,6 +95,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."plutus-certification" or (errorHandler.buildDepError "plutus-certification"))
+            (hsPkgs."dapps-certification-persistence" or (errorHandler.buildDepError "dapps-certification-persistence"))
             ];
           buildable = true;
           modules = [ "Paths_plutus_certification" ];

--- a/nix/materialized/x86_64-darwin/default.nix
+++ b/nix/materialized/x86_64-darwin/default.nix
@@ -2,15 +2,22 @@
   pkgs = hackage:
     {
       packages = {
+        "charset".revision = (((hackage."charset")."0.3.9").revisions).default;
         "old-time".revision = (((hackage."old-time")."1.1.0.3").revisions).default;
         "servant-client".revision = (((hackage."servant-client")."0.19").revisions).default;
         "mmorph".revision = (((hackage."mmorph")."1.2.0").revisions).default;
+        "postgresql-binary".revision = (((hackage."postgresql-binary")."0.12.5").revisions).default;
         "happy".revision = (((hackage."happy")."1.20.0").revisions).default;
         "streaming-commons".revision = (((hackage."streaming-commons")."0.2.2.4").revisions).default;
         "streaming-commons".flags.use-bytestring-builder = false;
         "pretty".revision = (((hackage."pretty")."1.1.3.6").revisions).default;
         "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
+        "data-textual".revision = (((hackage."data-textual")."0.3.0.3").revisions).default;
         "network-uri".revision = (((hackage."network-uri")."2.6.4.1").revisions).default;
+        "parsers".revision = (((hackage."parsers")."0.12.11").revisions).default;
+        "parsers".flags.parsec = true;
+        "parsers".flags.binary = true;
+        "parsers".flags.attoparsec = true;
         "unordered-containers".revision = (((hackage."unordered-containers")."0.2.19.1").revisions).default;
         "unordered-containers".flags.debug = false;
         "integer-logarithms".revision = (((hackage."integer-logarithms")."1.0.3.1").revisions).default;
@@ -54,6 +61,7 @@
         "some".revision = (((hackage."some")."1.0.4.1").revisions).default;
         "some".flags.newtype-unsafe = true;
         "temporary".revision = (((hackage."temporary")."1.3").revisions).default;
+        "selda".revision = (((hackage."selda")."0.5.2.0").revisions).default;
         "comonad".revision = (((hackage."comonad")."5.0.8").revisions).default;
         "comonad".flags.containers = true;
         "comonad".flags.distributive = true;
@@ -65,28 +73,35 @@
         "asn1-types".revision = (((hackage."asn1-types")."0.3.4").revisions).default;
         "base-compat".revision = (((hackage."base-compat")."0.12.2").revisions).default;
         "string-conversions".revision = (((hackage."string-conversions")."0.4.0.1").revisions).default;
+        "data-endian".revision = (((hackage."data-endian")."0.1.1").revisions).default;
         "bitvec".revision = (((hackage."bitvec")."1.1.3.0").revisions).default;
         "bitvec".flags.libgmp = false;
         "contravariant".revision = (((hackage."contravariant")."1.5.5").revisions).default;
         "contravariant".flags.tagged = true;
         "contravariant".flags.semigroups = true;
         "contravariant".flags.statevar = true;
+        "type-hint".revision = (((hackage."type-hint")."0.1").revisions).default;
         "base-compat-batteries".revision = (((hackage."base-compat-batteries")."0.12.2").revisions).default;
         "safe".revision = (((hackage."safe")."0.3.19").revisions).default;
         "Cabal".revision = (((hackage."Cabal")."3.6.3.0").revisions).default;
         "sop-core".revision = (((hackage."sop-core")."0.5.0.2").revisions).default;
         "assoc".revision = (((hackage."assoc")."1.0.2").revisions).default;
-        "cicero-api".revision = (((hackage."cicero-api")."0.1.1.3").revisions).default;
+        "cicero-api".revision = (((hackage."cicero-api")."0.1.2.0").revisions).default;
+        "binary-parser".revision = (((hackage."binary-parser")."0.5.7.2").revisions).default;
         "unliftio".revision = (((hackage."unliftio")."0.2.22.0").revisions).default;
         "data-fix".revision = (((hackage."data-fix")."0.3.2").revisions).default;
         "tls".revision = (((hackage."tls")."1.6.0").revisions).default;
         "tls".flags.network = true;
         "tls".flags.hans = false;
         "tls".flags.compat = true;
+        "text-printer".revision = (((hackage."text-printer")."0.5.0.2").revisions).default;
         "http-client-tls".revision = (((hackage."http-client-tls")."0.3.6.1").revisions).default;
+        "data-bword".revision = (((hackage."data-bword")."0.1.0.2").revisions).default;
         "basement".revision = (((hackage."basement")."0.0.15").revisions).default;
+        "network-ip".revision = (((hackage."network-ip")."0.3.0.3").revisions).default;
         "old-locale".revision = (((hackage."old-locale")."1.0.0.7").revisions).default;
         "mtl".revision = (((hackage."mtl")."2.2.2").revisions).default;
+        "selda-json".revision = (((hackage."selda-json")."0.1.1.1").revisions).default;
         "OneTuple".revision = (((hackage."OneTuple")."0.3.1").revisions).default;
         "mime-types".revision = (((hackage."mime-types")."0.1.1.0").revisions).default;
         "parsec".revision = (((hackage."parsec")."3.1.15.0").revisions).default;
@@ -94,6 +109,7 @@
         "attoparsec-iso8601".revision = (((hackage."attoparsec-iso8601")."1.0.2.1").revisions).default;
         "attoparsec-iso8601".flags.fast = false;
         "attoparsec-iso8601".flags.developer = false;
+        "data-dword".revision = (((hackage."data-dword")."0.3.2.1").revisions).default;
         "pem".revision = (((hackage."pem")."0.2.4").revisions).default;
         "strict".revision = (((hackage."strict")."0.4.0.1").revisions).default;
         "strict".flags.assoc = true;
@@ -111,10 +127,13 @@
         "splitmix".flags.optimised-mixer = false;
         "recv".revision = (((hackage."recv")."0.0.0").revisions).default;
         "file-embed".revision = (((hackage."file-embed")."0.0.15.0").revisions).default;
+        "text-latin1".revision = (((hackage."text-latin1")."0.3.1").revisions).default;
         "attoparsec".revision = (((hackage."attoparsec")."0.14.4").revisions).default;
         "attoparsec".flags.developer = false;
+        "bytestring-strict-builder".revision = (((hackage."bytestring-strict-builder")."0.4.5.6").revisions).default;
         "singleton-bool".revision = (((hackage."singleton-bool")."0.1.6").revisions).default;
         "th-compat".revision = (((hackage."th-compat")."0.1.4").revisions).default;
+        "data-checked".revision = (((hackage."data-checked")."0.3").revisions).default;
         "memory".revision = (((hackage."memory")."0.18.0").revisions).default;
         "memory".flags.support_deepseq = true;
         "memory".flags.support_bytestring = true;
@@ -140,6 +159,8 @@
         "free".revision = (((hackage."free")."5.1.9").revisions).default;
         "terminfo".revision = (((hackage."terminfo")."0.4.1.5").revisions).default;
         "connection".revision = (((hackage."connection")."0.3.1").revisions).default;
+        "postgresql-libpq".revision = (((hackage."postgresql-libpq")."0.9.4.3").revisions).default;
+        "postgresql-libpq".flags.use-pkg-config = false;
         "resourcet".revision = (((hackage."resourcet")."1.2.6").revisions).default;
         "vault".revision = (((hackage."vault")."0.3.1.5").revisions).default;
         "vault".flags.useghc = true;
@@ -162,6 +183,8 @@
         "vector-stream".revision = (((hackage."vector-stream")."0.1.0.0").revisions).default;
         "ghc-boot-th".revision = (((hackage."ghc-boot-th")."9.2.4").revisions).default;
         "asn1-encoding".revision = (((hackage."asn1-encoding")."0.9.6").revisions).default;
+        "selda-postgresql".revision = (((hackage."selda-postgresql")."0.1.8.2").revisions).default;
+        "selda-postgresql".flags.haste = false;
         "indexed-traversable".revision = (((hackage."indexed-traversable")."0.1.2").revisions).default;
         "distributive".revision = (((hackage."distributive")."0.6.2.1").revisions).default;
         "distributive".flags.tagged = true;
@@ -169,6 +192,7 @@
         "text-short".revision = (((hackage."text-short")."0.1.5").revisions).default;
         "text-short".flags.asserts = false;
         "servant".revision = (((hackage."servant")."0.19").revisions).default;
+        "data-serializer".revision = (((hackage."data-serializer")."0.3.5").revisions).default;
         "bsb-http-chunked".revision = (((hackage."bsb-http-chunked")."0.0.0.4").revisions).default;
         "bifunctors".revision = (((hackage."bifunctors")."5.5.13").revisions).default;
         "bifunctors".flags.tagged = true;
@@ -192,7 +216,7 @@
         "cereal".revision = (((hackage."cereal")."0.5.8.3").revisions).default;
         "cereal".flags.bytestring-builder = false;
         "utf8-string".revision = (((hackage."utf8-string")."1.0.2").revisions).default;
-        "conduit".revision = (((hackage."conduit")."1.3.4.2").revisions).default;
+        "conduit".revision = (((hackage."conduit")."1.3.4.3").revisions).default;
         "transformers-base".revision = (((hackage."transformers-base")."0.4.6").revisions).default;
         "transformers-base".flags.orphaninstances = true;
         "aeson-qq".revision = (((hackage."aeson-qq")."0.8.4").revisions).default;
@@ -218,6 +242,8 @@
         "base-unicode-symbols".flags.base-4-8 = true;
         "base-unicode-symbols".flags.old-base = false;
         "wai-logger".revision = (((hackage."wai-logger")."2.4.0").revisions).default;
+        "selda-sqlite".revision = (((hackage."selda-sqlite")."0.1.7.2").revisions).default;
+        "selda-sqlite".flags.haste = false;
         "these".revision = (((hackage."these")."1.1.1.1").revisions).default;
         "these".flags.assoc = true;
         "split".revision = (((hackage."split")."0.2.3.5").revisions).default;
@@ -251,6 +277,12 @@
         "wai-app-static".flags.print = false;
         "transformers".revision = (((hackage."transformers")."0.5.6.2").revisions).default;
         "template-haskell".revision = (((hackage."template-haskell")."2.18.0.0").revisions).default;
+        "direct-sqlite".revision = (((hackage."direct-sqlite")."2.3.27").revisions).default;
+        "direct-sqlite".flags.haveusleep = true;
+        "direct-sqlite".flags.systemlib = false;
+        "direct-sqlite".flags.fulltextsearch = true;
+        "direct-sqlite".flags.urifilenames = true;
+        "direct-sqlite".flags.json1 = true;
         "blaze-markup".revision = (((hackage."blaze-markup")."0.8.2.8").revisions).default;
         "mono-traversable".revision = (((hackage."mono-traversable")."1.0.15.3").revisions).default;
         "witherable".revision = (((hackage."witherable")."0.4.2").revisions).default;
@@ -349,6 +381,7 @@
       packages = {
         dapps-certification-interface = ./.plan.nix/dapps-certification-interface.nix;
         dapps-certification-helpers = ./.plan.nix/dapps-certification-helpers.nix;
+        dapps-certification-persistence = ./.plan.nix/dapps-certification-persistence.nix;
         plutus-certification = ./.plan.nix/plutus-certification.nix;
         };
       };
@@ -358,6 +391,7 @@
         packages = {
           "dapps-certification-interface" = { flags = {}; };
           "dapps-certification-helpers" = { flags = {}; };
+          "dapps-certification-persistence" = { flags = {}; };
           "plutus-certification" = { flags = {}; };
           };
         })
@@ -376,11 +410,13 @@
           "cookie".components.library.planned = lib.mkOverride 900 true;
           "these".components.library.planned = lib.mkOverride 900 true;
           "cereal".components.library.planned = lib.mkOverride 900 true;
+          "selda".components.library.planned = lib.mkOverride 900 true;
           "resourcet".components.library.planned = lib.mkOverride 900 true;
           "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "http2".components.library.planned = lib.mkOverride 900 true;
           "filepath".components.library.planned = lib.mkOverride 900 true;
           "wai".components.library.planned = lib.mkOverride 900 true;
+          "data-textual".components.library.planned = lib.mkOverride 900 true;
           "distributive".components.library.planned = lib.mkOverride 900 true;
           "pretty".components.library.planned = lib.mkOverride 900 true;
           "utf8-string".components.library.planned = lib.mkOverride 900 true;
@@ -391,7 +427,9 @@
           "mono-traversable".components.library.planned = lib.mkOverride 900 true;
           "zlib".components.library.planned = lib.mkOverride 900 true;
           "servant-server".components.exes."greet".planned = lib.mkOverride 900 true;
+          "data-dword".components.library.planned = lib.mkOverride 900 true;
           "strict".components.library.planned = lib.mkOverride 900 true;
+          "text-printer".components.library.planned = lib.mkOverride 900 true;
           "entropy".components.setup.planned = lib.mkOverride 900 true;
           "comonad".components.library.planned = lib.mkOverride 900 true;
           "data-fix".components.library.planned = lib.mkOverride 900 true;
@@ -407,6 +445,7 @@
           "dlist".components.library.planned = lib.mkOverride 900 true;
           "time-manager".components.library.planned = lib.mkOverride 900 true;
           "ghc-prim".components.library.planned = lib.mkOverride 900 true;
+          "postgresql-libpq".components.setup.planned = lib.mkOverride 900 true;
           "HUnit".components.library.planned = lib.mkOverride 900 true;
           "some".components.library.planned = lib.mkOverride 900 true;
           "array".components.library.planned = lib.mkOverride 900 true;
@@ -415,6 +454,7 @@
           "cicero-api".components.exes."cicero-cli".planned = lib.mkOverride 900 true;
           "dapps-certification-helpers".components.library.planned = lib.mkOverride 900 true;
           "binary".components.library.planned = lib.mkOverride 900 true;
+          "charset".components.library.planned = lib.mkOverride 900 true;
           "wai-extra".components.library.planned = lib.mkOverride 900 true;
           "ghc-boot-th".components.library.planned = lib.mkOverride 900 true;
           "scientific".components.library.planned = lib.mkOverride 900 true;
@@ -434,6 +474,7 @@
           "indexed-traversable-instances".components.library.planned = lib.mkOverride 900 true;
           "servant-server".components.library.planned = lib.mkOverride 900 true;
           "data-default-class".components.library.planned = lib.mkOverride 900 true;
+          "type-hint".components.library.planned = lib.mkOverride 900 true;
           "adjunctions".components.library.planned = lib.mkOverride 900 true;
           "cryptonite".components.library.planned = lib.mkOverride 900 true;
           "asn1-parse".components.library.planned = lib.mkOverride 900 true;
@@ -441,6 +482,7 @@
           "network-byte-order".components.library.planned = lib.mkOverride 900 true;
           "mime-types".components.library.planned = lib.mkOverride 900 true;
           "directory".components.library.planned = lib.mkOverride 900 true;
+          "network-ip".components.library.planned = lib.mkOverride 900 true;
           "happy".components.exes."happy".planned = lib.mkOverride 900 true;
           "network-info".components.library.planned = lib.mkOverride 900 true;
           "uuid".components.library.planned = lib.mkOverride 900 true;
@@ -458,6 +500,7 @@
           "haskeline".components.library.planned = lib.mkOverride 900 true;
           "th-expand-syns".components.library.planned = lib.mkOverride 900 true;
           "unix-time".components.library.planned = lib.mkOverride 900 true;
+          "direct-sqlite".components.library.planned = lib.mkOverride 900 true;
           "cryptohash-sha1".components.library.planned = lib.mkOverride 900 true;
           "free".components.library.planned = lib.mkOverride 900 true;
           "unix-compat".components.library.planned = lib.mkOverride 900 true;
@@ -473,6 +516,7 @@
           "indexed-traversable".components.library.planned = lib.mkOverride 900 true;
           "network-uri".components.library.planned = lib.mkOverride 900 true;
           "wai-logger".components.setup.planned = lib.mkOverride 900 true;
+          "data-serializer".components.library.planned = lib.mkOverride 900 true;
           "memory".components.library.planned = lib.mkOverride 900 true;
           "pem".components.library.planned = lib.mkOverride 900 true;
           "typed-process".components.library.planned = lib.mkOverride 900 true;
@@ -486,11 +530,14 @@
           "entropy".components.library.planned = lib.mkOverride 900 true;
           "assoc".components.library.planned = lib.mkOverride 900 true;
           "process".components.library.planned = lib.mkOverride 900 true;
+          "binary-parser".components.library.planned = lib.mkOverride 900 true;
+          "selda-postgresql".components.library.planned = lib.mkOverride 900 true;
           "http-date".components.library.planned = lib.mkOverride 900 true;
           "template-haskell".components.library.planned = lib.mkOverride 900 true;
           "blaze-markup".components.library.planned = lib.mkOverride 900 true;
           "th-lift".components.library.planned = lib.mkOverride 900 true;
           "stm".components.library.planned = lib.mkOverride 900 true;
+          "postgresql-binary".components.library.planned = lib.mkOverride 900 true;
           "byteorder".components.library.planned = lib.mkOverride 900 true;
           "witherable".components.library.planned = lib.mkOverride 900 true;
           "plutus-certification".components.library.planned = lib.mkOverride 900 true;
@@ -503,32 +550,40 @@
           "cabal-doctest".components.library.planned = lib.mkOverride 900 true;
           "iproute".components.library.planned = lib.mkOverride 900 true;
           "servant-client".components.library.planned = lib.mkOverride 900 true;
+          "selda-sqlite".components.library.planned = lib.mkOverride 900 true;
           "wai-logger".components.library.planned = lib.mkOverride 900 true;
           "th-compat".components.library.planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
+          "bytestring-strict-builder".components.library.planned = lib.mkOverride 900 true;
           "http-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
           "ansi-wl-pprint".components.library.planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "semigroupoids".components.library.planned = lib.mkOverride 900 true;
           "x509-validation".components.library.planned = lib.mkOverride 900 true;
+          "postgresql-libpq".components.library.planned = lib.mkOverride 900 true;
           "dapps-certification-helpers".components.exes."build-flake".planned = lib.mkOverride 900 true;
           "wai-app-static".components.exes."warp".planned = lib.mkOverride 900 true;
           "singleton-bool".components.library.planned = lib.mkOverride 900 true;
           "attoparsec".components.library.planned = lib.mkOverride 900 true;
+          "data-checked".components.library.planned = lib.mkOverride 900 true;
+          "dapps-certification-persistence".components.library.planned = lib.mkOverride 900 true;
           "mtl".components.library.planned = lib.mkOverride 900 true;
           "base-unicode-symbols".components.library.planned = lib.mkOverride 900 true;
           "aeson-qq".components.library.planned = lib.mkOverride 900 true;
           "vault".components.library.planned = lib.mkOverride 900 true;
           "th-abstraction".components.library.planned = lib.mkOverride 900 true;
           "attoparsec".components.sublibs."attoparsec-internal".planned = lib.mkOverride 900 true;
+          "parsers".components.library.planned = lib.mkOverride 900 true;
           "transformers".components.library.planned = lib.mkOverride 900 true;
           "wai-app-static".components.library.planned = lib.mkOverride 900 true;
+          "selda-json".components.library.planned = lib.mkOverride 900 true;
           "conduit-aeson".components.library.planned = lib.mkOverride 900 true;
           "OneTuple".components.library.planned = lib.mkOverride 900 true;
           "parsec".components.library.planned = lib.mkOverride 900 true;
           "deepseq".components.library.planned = lib.mkOverride 900 true;
           "primitive".components.library.planned = lib.mkOverride 900 true;
+          "text-latin1".components.library.planned = lib.mkOverride 900 true;
           "old-locale".components.library.planned = lib.mkOverride 900 true;
           "conduit".components.library.planned = lib.mkOverride 900 true;
           "eventuo11y".components.library.planned = lib.mkOverride 900 true;
@@ -551,6 +606,7 @@
           "th-reify-many".components.library.planned = lib.mkOverride 900 true;
           "dapps-certification-helpers".components.exes."generate-flake".planned = lib.mkOverride 900 true;
           "time-compat".components.library.planned = lib.mkOverride 900 true;
+          "data-endian".components.library.planned = lib.mkOverride 900 true;
           "basement".components.library.planned = lib.mkOverride 900 true;
           "optparse-applicative".components.library.planned = lib.mkOverride 900 true;
           "wai-cors".components.library.planned = lib.mkOverride 900 true;
@@ -558,6 +614,7 @@
           "x509-system".components.library.planned = lib.mkOverride 900 true;
           "hourglass".components.library.planned = lib.mkOverride 900 true;
           "base-compat".components.library.planned = lib.mkOverride 900 true;
+          "data-bword".components.library.planned = lib.mkOverride 900 true;
           "base64-bytestring".components.library.planned = lib.mkOverride 900 true;
           "hashable".components.library.planned = lib.mkOverride 900 true;
           "semigroups".components.library.planned = lib.mkOverride 900 true;

--- a/nix/materialized/x86_64-linux/.plan.nix/dapps-certification-persistence.nix
+++ b/nix/materialized/x86_64-linux/.plan.nix/dapps-certification-persistence.nix
@@ -1,0 +1,57 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = {
+        name = "dapps-certification-persistence";
+        version = "0.1.0.0";
+        };
+      license = "NONE";
+      copyright = "";
+      maintainer = "bogdan.manole@iohk.io";
+      author = "Bogdan Manole";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."selda" or (errorHandler.buildDepError "selda"))
+          (hsPkgs."selda-sqlite" or (errorHandler.buildDepError "selda-sqlite"))
+          (hsPkgs."selda-postgresql" or (errorHandler.buildDepError "selda-postgresql"))
+          (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          ];
+        buildable = true;
+        modules = [
+          "IOHK/Certification/Persistence/Structure"
+          "IOHK/Certification/Persistence/API"
+          "IOHK/Certification/Persistence"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../dapps-certification-persistence; }

--- a/nix/materialized/x86_64-linux/.plan.nix/plutus-certification.nix
+++ b/nix/materialized/x86_64-linux/.plan.nix/plutus-certification.nix
@@ -57,6 +57,7 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
+          (hsPkgs."dapps-certification-persistence" or (errorHandler.buildDepError "dapps-certification-persistence"))
           (hsPkgs."dapps-certification-interface" or (errorHandler.buildDepError "dapps-certification-interface"))
           (hsPkgs."dapps-certification-helpers" or (errorHandler.buildDepError "dapps-certification-helpers"))
           ];
@@ -69,6 +70,7 @@
           "Plutus/Certification/Client"
           "Plutus/Certification/Server"
           "Plutus/Certification/Local"
+          "Plutus/Certification/GithubClient"
           ];
         hsSourceDirs = [ "src" ];
         };
@@ -93,6 +95,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."plutus-certification" or (errorHandler.buildDepError "plutus-certification"))
+            (hsPkgs."dapps-certification-persistence" or (errorHandler.buildDepError "dapps-certification-persistence"))
             ];
           buildable = true;
           modules = [ "Paths_plutus_certification" ];

--- a/nix/materialized/x86_64-linux/default.nix
+++ b/nix/materialized/x86_64-linux/default.nix
@@ -2,15 +2,22 @@
   pkgs = hackage:
     {
       packages = {
+        "charset".revision = (((hackage."charset")."0.3.9").revisions).default;
         "old-time".revision = (((hackage."old-time")."1.1.0.3").revisions).default;
         "servant-client".revision = (((hackage."servant-client")."0.19").revisions).default;
         "mmorph".revision = (((hackage."mmorph")."1.2.0").revisions).default;
+        "postgresql-binary".revision = (((hackage."postgresql-binary")."0.12.5").revisions).default;
         "happy".revision = (((hackage."happy")."1.20.0").revisions).default;
         "streaming-commons".revision = (((hackage."streaming-commons")."0.2.2.4").revisions).default;
         "streaming-commons".flags.use-bytestring-builder = false;
         "pretty".revision = (((hackage."pretty")."1.1.3.6").revisions).default;
         "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
+        "data-textual".revision = (((hackage."data-textual")."0.3.0.3").revisions).default;
         "network-uri".revision = (((hackage."network-uri")."2.6.4.1").revisions).default;
+        "parsers".revision = (((hackage."parsers")."0.12.11").revisions).default;
+        "parsers".flags.parsec = true;
+        "parsers".flags.binary = true;
+        "parsers".flags.attoparsec = true;
         "unordered-containers".revision = (((hackage."unordered-containers")."0.2.19.1").revisions).default;
         "unordered-containers".flags.debug = false;
         "integer-logarithms".revision = (((hackage."integer-logarithms")."1.0.3.1").revisions).default;
@@ -54,6 +61,7 @@
         "some".revision = (((hackage."some")."1.0.4.1").revisions).default;
         "some".flags.newtype-unsafe = true;
         "temporary".revision = (((hackage."temporary")."1.3").revisions).default;
+        "selda".revision = (((hackage."selda")."0.5.2.0").revisions).default;
         "comonad".revision = (((hackage."comonad")."5.0.8").revisions).default;
         "comonad".flags.containers = true;
         "comonad".flags.distributive = true;
@@ -65,28 +73,35 @@
         "asn1-types".revision = (((hackage."asn1-types")."0.3.4").revisions).default;
         "base-compat".revision = (((hackage."base-compat")."0.12.2").revisions).default;
         "string-conversions".revision = (((hackage."string-conversions")."0.4.0.1").revisions).default;
+        "data-endian".revision = (((hackage."data-endian")."0.1.1").revisions).default;
         "bitvec".revision = (((hackage."bitvec")."1.1.3.0").revisions).default;
         "bitvec".flags.libgmp = false;
         "contravariant".revision = (((hackage."contravariant")."1.5.5").revisions).default;
         "contravariant".flags.tagged = true;
         "contravariant".flags.semigroups = true;
         "contravariant".flags.statevar = true;
+        "type-hint".revision = (((hackage."type-hint")."0.1").revisions).default;
         "base-compat-batteries".revision = (((hackage."base-compat-batteries")."0.12.2").revisions).default;
         "safe".revision = (((hackage."safe")."0.3.19").revisions).default;
         "Cabal".revision = (((hackage."Cabal")."3.6.3.0").revisions).default;
         "sop-core".revision = (((hackage."sop-core")."0.5.0.2").revisions).default;
         "assoc".revision = (((hackage."assoc")."1.0.2").revisions).default;
         "cicero-api".revision = (((hackage."cicero-api")."0.1.2.0").revisions).default;
+        "binary-parser".revision = (((hackage."binary-parser")."0.5.7.2").revisions).default;
         "unliftio".revision = (((hackage."unliftio")."0.2.22.0").revisions).default;
         "data-fix".revision = (((hackage."data-fix")."0.3.2").revisions).default;
         "tls".revision = (((hackage."tls")."1.6.0").revisions).default;
         "tls".flags.network = true;
         "tls".flags.hans = false;
         "tls".flags.compat = true;
+        "text-printer".revision = (((hackage."text-printer")."0.5.0.2").revisions).default;
         "http-client-tls".revision = (((hackage."http-client-tls")."0.3.6.1").revisions).default;
+        "data-bword".revision = (((hackage."data-bword")."0.1.0.2").revisions).default;
         "basement".revision = (((hackage."basement")."0.0.15").revisions).default;
+        "network-ip".revision = (((hackage."network-ip")."0.3.0.3").revisions).default;
         "old-locale".revision = (((hackage."old-locale")."1.0.0.7").revisions).default;
         "mtl".revision = (((hackage."mtl")."2.2.2").revisions).default;
+        "selda-json".revision = (((hackage."selda-json")."0.1.1.1").revisions).default;
         "OneTuple".revision = (((hackage."OneTuple")."0.3.1").revisions).default;
         "mime-types".revision = (((hackage."mime-types")."0.1.1.0").revisions).default;
         "parsec".revision = (((hackage."parsec")."3.1.15.0").revisions).default;
@@ -94,6 +109,7 @@
         "attoparsec-iso8601".revision = (((hackage."attoparsec-iso8601")."1.0.2.1").revisions).default;
         "attoparsec-iso8601".flags.fast = false;
         "attoparsec-iso8601".flags.developer = false;
+        "data-dword".revision = (((hackage."data-dword")."0.3.2.1").revisions).default;
         "pem".revision = (((hackage."pem")."0.2.4").revisions).default;
         "strict".revision = (((hackage."strict")."0.4.0.1").revisions).default;
         "strict".flags.assoc = true;
@@ -111,10 +127,13 @@
         "splitmix".flags.optimised-mixer = false;
         "recv".revision = (((hackage."recv")."0.0.0").revisions).default;
         "file-embed".revision = (((hackage."file-embed")."0.0.15.0").revisions).default;
+        "text-latin1".revision = (((hackage."text-latin1")."0.3.1").revisions).default;
         "attoparsec".revision = (((hackage."attoparsec")."0.14.4").revisions).default;
         "attoparsec".flags.developer = false;
+        "bytestring-strict-builder".revision = (((hackage."bytestring-strict-builder")."0.4.5.6").revisions).default;
         "singleton-bool".revision = (((hackage."singleton-bool")."0.1.6").revisions).default;
         "th-compat".revision = (((hackage."th-compat")."0.1.4").revisions).default;
+        "data-checked".revision = (((hackage."data-checked")."0.3").revisions).default;
         "memory".revision = (((hackage."memory")."0.18.0").revisions).default;
         "memory".flags.support_deepseq = true;
         "memory".flags.support_bytestring = true;
@@ -140,6 +159,8 @@
         "free".revision = (((hackage."free")."5.1.9").revisions).default;
         "terminfo".revision = (((hackage."terminfo")."0.4.1.5").revisions).default;
         "connection".revision = (((hackage."connection")."0.3.1").revisions).default;
+        "postgresql-libpq".revision = (((hackage."postgresql-libpq")."0.9.4.3").revisions).default;
+        "postgresql-libpq".flags.use-pkg-config = false;
         "resourcet".revision = (((hackage."resourcet")."1.2.6").revisions).default;
         "vault".revision = (((hackage."vault")."0.3.1.5").revisions).default;
         "vault".flags.useghc = true;
@@ -162,6 +183,8 @@
         "vector-stream".revision = (((hackage."vector-stream")."0.1.0.0").revisions).default;
         "ghc-boot-th".revision = (((hackage."ghc-boot-th")."9.2.4").revisions).default;
         "asn1-encoding".revision = (((hackage."asn1-encoding")."0.9.6").revisions).default;
+        "selda-postgresql".revision = (((hackage."selda-postgresql")."0.1.8.2").revisions).default;
+        "selda-postgresql".flags.haste = false;
         "indexed-traversable".revision = (((hackage."indexed-traversable")."0.1.2").revisions).default;
         "distributive".revision = (((hackage."distributive")."0.6.2.1").revisions).default;
         "distributive".flags.tagged = true;
@@ -169,6 +192,7 @@
         "text-short".revision = (((hackage."text-short")."0.1.5").revisions).default;
         "text-short".flags.asserts = false;
         "servant".revision = (((hackage."servant")."0.19").revisions).default;
+        "data-serializer".revision = (((hackage."data-serializer")."0.3.5").revisions).default;
         "bsb-http-chunked".revision = (((hackage."bsb-http-chunked")."0.0.0.4").revisions).default;
         "bifunctors".revision = (((hackage."bifunctors")."5.5.13").revisions).default;
         "bifunctors".flags.tagged = true;
@@ -218,6 +242,8 @@
         "base-unicode-symbols".flags.base-4-8 = true;
         "base-unicode-symbols".flags.old-base = false;
         "wai-logger".revision = (((hackage."wai-logger")."2.4.0").revisions).default;
+        "selda-sqlite".revision = (((hackage."selda-sqlite")."0.1.7.2").revisions).default;
+        "selda-sqlite".flags.haste = false;
         "these".revision = (((hackage."these")."1.1.1.1").revisions).default;
         "these".flags.assoc = true;
         "split".revision = (((hackage."split")."0.2.3.5").revisions).default;
@@ -251,6 +277,12 @@
         "wai-app-static".flags.print = false;
         "transformers".revision = (((hackage."transformers")."0.5.6.2").revisions).default;
         "template-haskell".revision = (((hackage."template-haskell")."2.18.0.0").revisions).default;
+        "direct-sqlite".revision = (((hackage."direct-sqlite")."2.3.27").revisions).default;
+        "direct-sqlite".flags.haveusleep = true;
+        "direct-sqlite".flags.systemlib = false;
+        "direct-sqlite".flags.fulltextsearch = true;
+        "direct-sqlite".flags.urifilenames = true;
+        "direct-sqlite".flags.json1 = true;
         "blaze-markup".revision = (((hackage."blaze-markup")."0.8.2.8").revisions).default;
         "mono-traversable".revision = (((hackage."mono-traversable")."1.0.15.3").revisions).default;
         "witherable".revision = (((hackage."witherable")."0.4.2").revisions).default;
@@ -349,6 +381,7 @@
       packages = {
         dapps-certification-interface = ./.plan.nix/dapps-certification-interface.nix;
         dapps-certification-helpers = ./.plan.nix/dapps-certification-helpers.nix;
+        dapps-certification-persistence = ./.plan.nix/dapps-certification-persistence.nix;
         plutus-certification = ./.plan.nix/plutus-certification.nix;
         };
       };
@@ -358,6 +391,7 @@
         packages = {
           "dapps-certification-interface" = { flags = {}; };
           "dapps-certification-helpers" = { flags = {}; };
+          "dapps-certification-persistence" = { flags = {}; };
           "plutus-certification" = { flags = {}; };
           };
         })
@@ -376,11 +410,13 @@
           "cookie".components.library.planned = lib.mkOverride 900 true;
           "these".components.library.planned = lib.mkOverride 900 true;
           "cereal".components.library.planned = lib.mkOverride 900 true;
+          "selda".components.library.planned = lib.mkOverride 900 true;
           "resourcet".components.library.planned = lib.mkOverride 900 true;
           "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "http2".components.library.planned = lib.mkOverride 900 true;
           "filepath".components.library.planned = lib.mkOverride 900 true;
           "wai".components.library.planned = lib.mkOverride 900 true;
+          "data-textual".components.library.planned = lib.mkOverride 900 true;
           "distributive".components.library.planned = lib.mkOverride 900 true;
           "pretty".components.library.planned = lib.mkOverride 900 true;
           "utf8-string".components.library.planned = lib.mkOverride 900 true;
@@ -391,7 +427,9 @@
           "mono-traversable".components.library.planned = lib.mkOverride 900 true;
           "zlib".components.library.planned = lib.mkOverride 900 true;
           "servant-server".components.exes."greet".planned = lib.mkOverride 900 true;
+          "data-dword".components.library.planned = lib.mkOverride 900 true;
           "strict".components.library.planned = lib.mkOverride 900 true;
+          "text-printer".components.library.planned = lib.mkOverride 900 true;
           "entropy".components.setup.planned = lib.mkOverride 900 true;
           "comonad".components.library.planned = lib.mkOverride 900 true;
           "data-fix".components.library.planned = lib.mkOverride 900 true;
@@ -407,6 +445,7 @@
           "dlist".components.library.planned = lib.mkOverride 900 true;
           "time-manager".components.library.planned = lib.mkOverride 900 true;
           "ghc-prim".components.library.planned = lib.mkOverride 900 true;
+          "postgresql-libpq".components.setup.planned = lib.mkOverride 900 true;
           "HUnit".components.library.planned = lib.mkOverride 900 true;
           "some".components.library.planned = lib.mkOverride 900 true;
           "array".components.library.planned = lib.mkOverride 900 true;
@@ -415,6 +454,7 @@
           "cicero-api".components.exes."cicero-cli".planned = lib.mkOverride 900 true;
           "dapps-certification-helpers".components.library.planned = lib.mkOverride 900 true;
           "binary".components.library.planned = lib.mkOverride 900 true;
+          "charset".components.library.planned = lib.mkOverride 900 true;
           "wai-extra".components.library.planned = lib.mkOverride 900 true;
           "ghc-boot-th".components.library.planned = lib.mkOverride 900 true;
           "scientific".components.library.planned = lib.mkOverride 900 true;
@@ -434,6 +474,7 @@
           "indexed-traversable-instances".components.library.planned = lib.mkOverride 900 true;
           "servant-server".components.library.planned = lib.mkOverride 900 true;
           "data-default-class".components.library.planned = lib.mkOverride 900 true;
+          "type-hint".components.library.planned = lib.mkOverride 900 true;
           "adjunctions".components.library.planned = lib.mkOverride 900 true;
           "cryptonite".components.library.planned = lib.mkOverride 900 true;
           "asn1-parse".components.library.planned = lib.mkOverride 900 true;
@@ -441,6 +482,7 @@
           "network-byte-order".components.library.planned = lib.mkOverride 900 true;
           "mime-types".components.library.planned = lib.mkOverride 900 true;
           "directory".components.library.planned = lib.mkOverride 900 true;
+          "network-ip".components.library.planned = lib.mkOverride 900 true;
           "happy".components.exes."happy".planned = lib.mkOverride 900 true;
           "network-info".components.library.planned = lib.mkOverride 900 true;
           "uuid".components.library.planned = lib.mkOverride 900 true;
@@ -458,6 +500,7 @@
           "haskeline".components.library.planned = lib.mkOverride 900 true;
           "th-expand-syns".components.library.planned = lib.mkOverride 900 true;
           "unix-time".components.library.planned = lib.mkOverride 900 true;
+          "direct-sqlite".components.library.planned = lib.mkOverride 900 true;
           "cryptohash-sha1".components.library.planned = lib.mkOverride 900 true;
           "free".components.library.planned = lib.mkOverride 900 true;
           "unix-compat".components.library.planned = lib.mkOverride 900 true;
@@ -473,6 +516,7 @@
           "indexed-traversable".components.library.planned = lib.mkOverride 900 true;
           "network-uri".components.library.planned = lib.mkOverride 900 true;
           "wai-logger".components.setup.planned = lib.mkOverride 900 true;
+          "data-serializer".components.library.planned = lib.mkOverride 900 true;
           "memory".components.library.planned = lib.mkOverride 900 true;
           "pem".components.library.planned = lib.mkOverride 900 true;
           "typed-process".components.library.planned = lib.mkOverride 900 true;
@@ -486,11 +530,14 @@
           "entropy".components.library.planned = lib.mkOverride 900 true;
           "assoc".components.library.planned = lib.mkOverride 900 true;
           "process".components.library.planned = lib.mkOverride 900 true;
+          "binary-parser".components.library.planned = lib.mkOverride 900 true;
+          "selda-postgresql".components.library.planned = lib.mkOverride 900 true;
           "http-date".components.library.planned = lib.mkOverride 900 true;
           "template-haskell".components.library.planned = lib.mkOverride 900 true;
           "blaze-markup".components.library.planned = lib.mkOverride 900 true;
           "th-lift".components.library.planned = lib.mkOverride 900 true;
           "stm".components.library.planned = lib.mkOverride 900 true;
+          "postgresql-binary".components.library.planned = lib.mkOverride 900 true;
           "byteorder".components.library.planned = lib.mkOverride 900 true;
           "witherable".components.library.planned = lib.mkOverride 900 true;
           "plutus-certification".components.library.planned = lib.mkOverride 900 true;
@@ -503,32 +550,40 @@
           "cabal-doctest".components.library.planned = lib.mkOverride 900 true;
           "iproute".components.library.planned = lib.mkOverride 900 true;
           "servant-client".components.library.planned = lib.mkOverride 900 true;
+          "selda-sqlite".components.library.planned = lib.mkOverride 900 true;
           "wai-logger".components.library.planned = lib.mkOverride 900 true;
           "th-compat".components.library.planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
+          "bytestring-strict-builder".components.library.planned = lib.mkOverride 900 true;
           "http-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
           "ansi-wl-pprint".components.library.planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "semigroupoids".components.library.planned = lib.mkOverride 900 true;
           "x509-validation".components.library.planned = lib.mkOverride 900 true;
+          "postgresql-libpq".components.library.planned = lib.mkOverride 900 true;
           "dapps-certification-helpers".components.exes."build-flake".planned = lib.mkOverride 900 true;
           "wai-app-static".components.exes."warp".planned = lib.mkOverride 900 true;
           "singleton-bool".components.library.planned = lib.mkOverride 900 true;
           "attoparsec".components.library.planned = lib.mkOverride 900 true;
+          "data-checked".components.library.planned = lib.mkOverride 900 true;
+          "dapps-certification-persistence".components.library.planned = lib.mkOverride 900 true;
           "mtl".components.library.planned = lib.mkOverride 900 true;
           "base-unicode-symbols".components.library.planned = lib.mkOverride 900 true;
           "aeson-qq".components.library.planned = lib.mkOverride 900 true;
           "vault".components.library.planned = lib.mkOverride 900 true;
           "th-abstraction".components.library.planned = lib.mkOverride 900 true;
           "attoparsec".components.sublibs."attoparsec-internal".planned = lib.mkOverride 900 true;
+          "parsers".components.library.planned = lib.mkOverride 900 true;
           "transformers".components.library.planned = lib.mkOverride 900 true;
           "wai-app-static".components.library.planned = lib.mkOverride 900 true;
+          "selda-json".components.library.planned = lib.mkOverride 900 true;
           "conduit-aeson".components.library.planned = lib.mkOverride 900 true;
           "OneTuple".components.library.planned = lib.mkOverride 900 true;
           "parsec".components.library.planned = lib.mkOverride 900 true;
           "deepseq".components.library.planned = lib.mkOverride 900 true;
           "primitive".components.library.planned = lib.mkOverride 900 true;
+          "text-latin1".components.library.planned = lib.mkOverride 900 true;
           "old-locale".components.library.planned = lib.mkOverride 900 true;
           "conduit".components.library.planned = lib.mkOverride 900 true;
           "eventuo11y".components.library.planned = lib.mkOverride 900 true;
@@ -551,6 +606,7 @@
           "th-reify-many".components.library.planned = lib.mkOverride 900 true;
           "dapps-certification-helpers".components.exes."generate-flake".planned = lib.mkOverride 900 true;
           "time-compat".components.library.planned = lib.mkOverride 900 true;
+          "data-endian".components.library.planned = lib.mkOverride 900 true;
           "basement".components.library.planned = lib.mkOverride 900 true;
           "optparse-applicative".components.library.planned = lib.mkOverride 900 true;
           "wai-cors".components.library.planned = lib.mkOverride 900 true;
@@ -558,6 +614,7 @@
           "x509-system".components.library.planned = lib.mkOverride 900 true;
           "hourglass".components.library.planned = lib.mkOverride 900 true;
           "base-compat".components.library.planned = lib.mkOverride 900 true;
+          "data-bword".components.library.planned = lib.mkOverride 900 true;
           "base64-bytestring".components.library.planned = lib.mkOverride 900 true;
           "hashable".components.library.planned = lib.mkOverride 900 true;
           "semigroups".components.library.planned = lib.mkOverride 900 true;

--- a/plutus-certification.cabal
+++ b/plutus-certification.cabal
@@ -43,6 +43,7 @@ library
     time ^>= 1.11.1.1,
     filepath,
     temporary,
+    dapps-certification-persistence,
     dapps-certification-interface,
     dapps-certification-helpers
   hs-source-dirs: src
@@ -53,6 +54,7 @@ library
     Plutus.Certification.Client
     Plutus.Certification.Server
     Plutus.Certification.Local
+    Plutus.Certification.GithubClient
   other-modules: Paths_plutus_certification
   autogen-modules: Paths_plutus_certification
   default-language: Haskell2010
@@ -76,7 +78,8 @@ executable plutus-certification
     singletons ^>= 3.0.1,
     text ^>= 1.2.5.0,
     bytestring ^>= 0.11.1.0,
-    plutus-certification
+    plutus-certification,
+    dapps-certification-persistence,
   main-is: Main.hs
   hs-source-dirs: server
   other-modules: Paths_plutus_certification

--- a/src/Plutus/Certification/GithubClient.hs
+++ b/src/Plutus/Certification/GithubClient.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Plutus.Certification.GithubClient (
+  getCommitInfo,
+  CommonResponse(..),
+  Author(..),
+  Commit(..),
+  CommitDetails(..)
+  ) where
+
+import Data.Aeson
+import Data.Proxy
+import GHC.Generics
+import Network.HTTP.Client      hiding (Proxy)
+import Network.HTTP.Client.TLS
+import Servant.API
+import Servant.Client
+import Data.Text
+import Data.Time
+
+data CommonResponse = CommonResponse {
+    commonRespCommit :: Commit
+} deriving (Show, Generic)
+
+data Author = Author
+  { name :: Text
+  , email :: Text
+  , date :: UTCTime
+} deriving (Show, Generic)
+
+data CommitDetails = CommitDetails
+  { author :: Author
+  , message :: Text
+  , committer :: Author
+  } deriving (Show, Generic)
+
+data Commit = Commit
+  { sha :: Text
+  , commit :: CommitDetails
+  } deriving (Show, Generic)
+
+instance FromJSON CommonResponse where
+    parseJSON = withObject "CommonResponse" $ \v -> CommonResponse <$> v .: "commit"
+
+instance FromJSON Commit
+instance FromJSON CommitDetails
+instance FromJSON Author
+
+type API = "repos"
+         :> Header "User-Agent" Text
+         :> Capture "owner" Text
+         :> Capture "repo" Text
+         :> (  "branches" :> Capture "branch" Text :> Get '[JSON] CommonResponse
+          :<|> "commits" :> Capture "commit" Text :> Get '[JSON] CommonResponse
+            )
+
+api :: Proxy API
+api = Proxy
+
+mkClient :: Text -> Text -> (Text -> ClientM CommonResponse) :<|> (Text -> ClientM CommonResponse)
+mkClient = (client api) (Just "")
+
+getCommitInfo :: Text
+              -> Text
+              -> Text
+              -> IO (Either ClientError Commit)
+getCommitInfo owner repo path' = do
+  manager' <- newManager tlsManagerSettings
+  let settings  = (mkClientEnv manager' (BaseUrl Https "api.github.com" 443 ""))
+  let getBranch :<|> getCommit = mkClient owner repo
+
+  -- first try branch
+  fmap commonRespCommit <$> do
+        respE <- runClientM (getBranch path' ) settings
+        case respE of
+          Left _ -> runClientM (getCommit path' ) settings
+          _ -> pure respE
+

--- a/src/Plutus/Certification/Server.hs
+++ b/src/Plutus/Certification/Server.hs
@@ -24,8 +24,16 @@ import Network.URI
 import IOHK.Certification.Interface
 import Servant.Server.Experimental.Auth
 import Plutus.Certification.API as API
-import Paths_plutus_certification qualified as Package
+import Plutus.Certification.GithubClient 
+import qualified IOHK.Certification.Persistence as DB
+import Control.Monad.Except
 import Data.Time.LocalTime
+import Data.Maybe
+import Data.Time
+import Data.Text hiding (replicate, last)
+import Data.ByteString.Lazy.Char8 qualified as LSB
+import Paths_plutus_certification qualified as Package
+
 
 -- | Capabilities needed to run a server for 'API'
 data ServerCaps m r = ServerCaps
@@ -68,31 +76,62 @@ renderServerEventSelector GetRun = ("get-run", absurd)
 renderServerEventSelector AbortRun = ("abort-run", \rid -> ("run-id",toJSON rid))
 renderServerEventSelector GetRunLogs = ("get-run-logs", \rid -> ("run-id",toJSON rid))
 
-newtype UserAddress = UserAddress { unUserAddress :: String} -- TODO: replace with Text / BS
+newtype UserAddress = UserAddress { unUserAddress :: Text}
 
-data UserId = UserId Int
-            deriving Show
+type instance AuthServerData (AuthProtect "public-key") = (DB.ProfileId,UserAddress)
 
--- | We need to specify the data returned after authentication
-type instance AuthServerData (AuthProtect "public-key") = UserId
+toDbStatus :: RunStatusV1 -> DB.Status
+toDbStatus (Finished _)= DB.Succeeded
+toDbStatus (Incomplete (Preparing Failed)) = DB.Failed
+toDbStatus (Incomplete (Building Failed)) = DB.Failed
+toDbStatus (Incomplete (Certifying (CertifyingStatus Failed _ _))) = DB.Failed
+toDbStatus _ = DB.Queued
+
+fromFlakeToCommitDate :: FlakeRefV1 -> IO UTCTime
+fromFlakeToCommitDate = undefined
+  where
+
+--NOTE
+getLastPart :: URI -> String
+getLastPart uri = last $ pathSegments uri
 
 -- | An implementation of 'API'
-server :: (MonadMask m,MonadIO m) => ServerCaps m r -> EventBackend m r ServerEventSelector -> ServerT API m
+server :: (MonadMask m,MonadIO m, MonadError ServerError m)
+       => ServerCaps m r
+       -> EventBackend m r ServerEventSelector
+       -> ServerT API m
 server ServerCaps {..} eb = NamedAPI
   { version = withEvent eb Version . const . pure $ VersionV1 Package.version
   , versionHead = withEvent eb Version . const $ pure NoContent
-  , createRun = \_ fref -> withEvent eb CreateRun \ev -> do
+  , createRun = \(profileId,_) fref@FlakeRef{..} -> withEvent eb CreateRun \ev -> do
+      -- ensure the ref is in the right format before start the job
+      commitDate <- getCommitDate uri
       addField ev $ CreateRunRef fref
       res <- submitJob (setAncestor $ reference ev) fref
       addField ev $ CreateRunID res
+      createDbRun fref profileId res commitDate
       pure res
-  , getRun = \rid -> withEvent eb GetRun \ev ->
-     runConduit
-        $ getRuns (setAncestor $ reference ev) rid
-       .| evalStateC Queued consumeRuns
-  , abortRun = \_ rid -> withEvent eb AbortRun \ev -> do
-     addField ev rid
-     const NoContent <$> (abortRuns (setAncestor $ reference ev) rid)
+  , getRun = \rid@RunID{..} -> withEvent eb GetRun \ev -> (
+      runConduit
+        $ getRuns (setAncestor $ reference ev) rid .| evalStateC Queued consumeRuns
+      ) >>= dbSync uuid
+
+  , abortRun = \(profileId,_) rid@RunID{..} -> withEvent eb AbortRun \ev -> do
+      addField ev rid
+      -- ensure is no already finished
+      status <- runConduit $
+        getRuns (setAncestor $ reference ev) rid .| evalStateC Queued consumeRuns
+      unless (toDbStatus status == DB.Queued) $
+        throwError err403 { errBody = "Run already finished"}
+      -- ensure is the owner of the run
+      isOwner <- (== (Just profileId)) <$> (DB.withDb $ DB.getRunOwner uuid)
+      unless (isOwner) $ throwError err403
+      -- finally abort the run
+      resp <- const NoContent <$> (abortRuns (setAncestor $ reference ev) rid)
+      -- if abortion succeeded mark it in the db
+      void (getNow >>= DB.withDb . DB.updateFinishedRun uuid False)
+
+      pure resp
   , getLogs = \rid afterM actionTypeM -> withEvent eb GetRunLogs \ev -> do
       addField ev rid
       let dropCond = case afterM of
@@ -103,8 +142,39 @@ server ServerCaps {..} eb = NamedAPI
       runConduit
          $ getLogs (setAncestor $ reference ev) actionTypeM rid
         .| (dropWhileC dropCond >> sinkList)
+  , getRuns = \(profileId,_) afterM countM -> do
+      DB.withDb $ DB.getRuns profileId afterM countM
+  , updateCurrentProfile = \(profileId,UserAddress ownerAddress) ProfileBody{..} -> do
+      DB.withDb $ do
+        _ <- DB.upsertProfile (DB.Profile{..})
+        -- it's safe to call partial function fromJust
+        fromJust <$> DB.getProfile profileId
+  , getCurrentProfile = \(profileId,_) ->
+      let notFound = throwError $ err404 { errBody = "Profile not found" }
+      in (DB.withDb $ DB.getProfile profileId) >>= maybe notFound pure
   }
   where
+    getCommitDate uri = do
+      (owner,repo,path') <- extractUriSegments uri
+      commitInfoE <- liftIO $ getCommitInfo owner repo path'
+      case commitInfoE of
+           Left e -> throwError err400 { errBody = LSB.pack $ show e}
+           Right (Commit _ (CommitDetails _ _ (Author _ _ time))) -> pure time
+    extractUriSegments uri = case fmap pack $ pathSegments uri of
+        owner:repo:path':_ -> pure (owner,repo,path')
+        _ -> throwError err400 { errBody = "Wrong flake-ref details"}
+    getNow = liftIO $ getCurrentTime
+    createDbRun FlakeRef{..} profileId res commitDate = do
+      now <- getNow
+      let uriTxt = pack $ uriToString id uri ""
+      DB.withDb $ DB.createRun (uuid res) now uriTxt commitDate profileId
+    dbSync uuid status = do
+      now <- getNow
+      let dbStatus = toDbStatus status
+      void $ DB.withDb $ case dbStatus of
+        DB.Queued -> DB.syncRun uuid now
+        _ -> DB.updateFinishedRun uuid (dbStatus == DB.Succeeded) now
+      return status
     consumeRuns = await >>= \case
       Nothing -> Incomplete <$> get
       Just (Incomplete s) -> do
@@ -135,3 +205,4 @@ server ServerCaps {..} eb = NamedAPI
                 _ -> s
         consumeRuns
       Just s -> pure s
+


### PR DESCRIPTION
- adding a persistence method for extra information :
       - Dapp Profile
       - History runs

-  Since the fetching on Cicero takes some time at this moment, the runs synchronisation with the database is done each time time the user is asking for the run information `run/{:id}` in opposition with an worker or other method which might end up in slowing the overall synchronisation process

TODOs in future tasks:
    - enabling  Postgresql for production purposes instead of SQLite
    - add instrumentation for the database operations
    - improve the synchronisation "real-timeness"
    - solve other remaining "TODO:" comments 