### PR TITLE
feat: split dapp information (DAC-396)

### DIFF
--- a/client/Main.hs
+++ b/client/Main.hs
@@ -42,10 +42,10 @@ flakeRefReader = do
 
 createRunParser :: Parser CreateRunArgs
 createRunParser = CreateRunArgs
-  <$> argument flakeRefReader
+  <$> (CommitOrBranch <$> (option str
     ( metavar "REF"
    <> help "the flake reference pointing to the repo to build"
-    )
+    )))
   <*> publicKeyParser
 
 createRunInfo :: ParserInfo CreateRunArgs
@@ -169,7 +169,7 @@ runCommandParser = hsubparser
  <> command "create-certification" (CreateCertification <$> createCertificationInfo)
   )
 
-data CreateRunArgs = CreateRunArgs !FlakeRefV1 !PublicKey
+data CreateRunArgs = CreateRunArgs !CommitOrBranch !PublicKey
 
 data GetRunsArgs = GetRunsArgs !PublicKey !(Maybe UTCTime) !(Maybe Int)
 

--- a/client/Main.hs
+++ b/client/Main.hs
@@ -211,13 +211,32 @@ updateCurrentProfileInfoParser = UpdateCurrentProfileArgs
   <$> publicKeyParser
   <*> profileBodyParser
 
+dappBodyParser :: Parser DAppBody
+dappBodyParser = DAppBody
+  <$> option str
+        ( long "dapp-name"
+       <> metavar "DAPP_NAME"
+       <> help "dapp name"
+        )
+  <*> option str
+        ( long "dapp-owner"
+       <> metavar "DAPP_GITHUB_OWNER"
+       <> help "dapp github owner"
+        )
+  <*> option str
+        ( long "dapp-repo"
+       <> metavar "DAPP_GITHUB_REPO"
+       <> help "dapp github repo"
+        )
+  <*> option str
+        ( long "dapp-version"
+       <> metavar "DAPP_VERSION"
+       <> help "dapp version"
+        )
+
 profileBodyParser :: Parser ProfileBody
 profileBodyParser = ProfileBody
-  <$> optional (option str
-        ( long "dapp"
-       <> metavar "DAPP_NAME"
-       <> help "dapp identification"
-        ))
+  <$> optional dappBodyParser
   <*> optional (option str
         ( long "website"
        <> metavar "WEBSITE"
@@ -247,11 +266,6 @@ profileBodyParser = ProfileBody
         ( long "contacts"
        <> metavar "CONTACTS"
        <> help "the list of contacts represented as a string"
-        ))
-  <*> optional (option str
-        ( long "version"
-       <> metavar "DAPP_VERSION"
-       <> help "DApp version"
         ))
 
 getCurrentProfileInfo :: ParserInfo PublicKey

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
@@ -5,6 +5,7 @@ import IOHK.Certification.Persistence.Structure as X
   , DApp(..)
   , Profile(..)
   , Certification(..)
+  , ProfileDTO(..)
   , profiles
   , runs
   , authors

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
@@ -16,6 +16,7 @@ import IOHK.Certification.Persistence.Structure as X
 import IOHK.Certification.Persistence.API as X
   ( upsertProfile
   , getProfile
+  , getProfileDApp
   , createRun
   , updateFinishedRun
   , getRuns

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence/API.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence/API.hs
@@ -59,9 +59,16 @@ getProfileQ pid = do
   restrict (profile ! #profileId .== literal pid)
   pure (profile :*: dapp)
 
+getProfileDAppQ :: ID Profile -> Query t (Row t DApp)
+getProfileDAppQ pid = do
+  dapp <- select dapps
+  restrict (dapp ! #dappId .== literal pid)
+  pure dapp
+
 getProfile :: MonadSelda m => ID Profile -> m (Maybe ProfileDTO)
-getProfile pid = do
-  fmap (fmap toProfileDTO . listToMaybe ) $ query $ getProfileQ pid
+getProfile pid = fmap (fmap toProfileDTO . listToMaybe ) $ query $ getProfileQ pid
+
+getProfileDApp pid = fmap (listToMaybe ) $ query $ getProfileDAppQ pid
 
 toProfileDTO :: (Profile :*: Maybe DApp) -> ProfileDTO
 toProfileDTO (profile :*: dapp) = ProfileDTO{..}
@@ -84,7 +91,14 @@ getProfileAddressQ  pid = do
 getProfileAddress :: MonadSelda m => ID Profile -> m (Maybe Text)
 getProfileAddress = fmap listToMaybe . query . getProfileAddressQ
 
-createRun :: MonadSelda m => UUID -> UTCTime -> Text -> UTCTime -> CommitHash -> ID Profile -> m ()
+createRun :: MonadSelda m
+          => UUID
+          -> UTCTime
+          -> Text
+          -> UTCTime
+          -> CommitHash
+          -> ID Profile
+          -> m ()
 createRun runId time repo commitDate commitHash pid = do
   void $ insert runs [Run runId time (Just time) time repo commitDate commitHash Queued pid]
 

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -174,8 +174,9 @@ authHandler = mkAuthHandler handler
     case profileIdM of
       Just pid -> pure (pid, UserAddress address)
       Nothing -> do
-        pidM <- DB.withDb $ DB.upsertProfile $ DB.Profile undefined address Nothing Nothing
-          Nothing Nothing Nothing Nothing Nothing Nothing
+        pidM <- DB.withDb $ DB.upsertProfile
+          (DB.Profile undefined address Nothing Nothing Nothing Nothing Nothing Nothing)
+          Nothing
         case pidM of
           Nothing -> throw $ err500 { errBody = "Profile couldn't be created" }
           Just pid -> pure (pid,UserAddress address)

--- a/src/Plutus/Certification/API.hs
+++ b/src/Plutus/Certification/API.hs
@@ -11,6 +11,7 @@ import Plutus.Certification.API.Routes as X
   , VersionV1(..)
   , RunIDV1(..)
   , FlakeRefV1(..)
+  , CommitOrBranch(..)
   , RunStatusV1(..)
   , StepState(..)
   , CertifyingStatus(..)

--- a/src/Plutus/Certification/API.hs
+++ b/src/Plutus/Certification/API.hs
@@ -17,6 +17,7 @@ import Plutus.Certification.API.Routes as X
   , IncompleteRunStatus(..)
   , KnownActionType(..)
   , ProfileBody(..)
+  , DAppBody(..)
   )
 import Plutus.Certification.API.Swagger as X 
   ( swaggerJson

--- a/src/Plutus/Certification/Server.hs
+++ b/src/Plutus/Certification/Server.hs
@@ -163,9 +163,12 @@ server ServerCaps {..} eb = NamedAPI
   , getRuns = \(profileId,_) afterM countM -> do
       DB.withDb $ DB.getRuns profileId afterM countM
   , updateCurrentProfile = \(profileId,UserAddress ownerAddress) ProfileBody{..} -> do
+      let dappId = profileId
+      let dappM = fmap (\DAppBody{..} -> DB.DApp{..}) dapp
       DB.withDb $ do
-        _ <- DB.upsertProfile (DB.Profile{..})
+        _ <- DB.upsertProfile (DB.Profile{..}) dappM
         -- it's safe to call partial function fromJust
+
         fromJust <$> DB.getProfile profileId
   , getCurrentProfile = \(profileId,_) ->
       let notFound = throwError $ err404 { errBody = "Profile not found" }


### PR DESCRIPTION
- split the dapp address into owner/repo (GH)
- separate the dapp name address and version into an optional separate entity
- make create run to accept only the commit/branch instead the full GitHub URL ( getting the rest of the GitHub URL from the profile)