### PR TITLE
feat: certificate broadcasting ( DAC-287 , DAC-369 )

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ run.sh
 docker-compose.yml
 Dockerfile.web
 Dockerfile.ws
+docker-files/wallet-container-instructions.md

--- a/dapps-certification-helpers/src/IOHK/Certification/Actions.hs
+++ b/dapps-certification-helpers/src/IOHK/Certification/Actions.hs
@@ -63,7 +63,7 @@ generateFlake backend addLogEntry flakeref output = withEvent backend GenerateFl
     hPutStrLn h "  inputs = {"
     hPutStr   h "    repo = " >> writeNix h lock >> hPutStrLn h ";"
     hPutStrLn h "    plutus-apps = {"
-    hPutStrLn h "      url = \"github:input-output-hk/plutus-apps\";"
+    hPutStrLn h "      url = \"github:input-output-hk/plutus-apps/1651d36a0f6458e7d2326d57dbc1baa00034d70d\";"
     hPutStrLn h "      flake = false;"
     hPutStrLn h "    };"
     hPutStrLn h "    dapps-certification = {"

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
@@ -12,6 +12,8 @@ import IOHK.Certification.Persistence.Structure as X
   , contacts
   , createTables
   , ProfileId
+  , IpfsCid(..)
+  , TxId(..)
   )
 import IOHK.Certification.Persistence.API as X
   ( upsertProfile

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
@@ -18,6 +18,7 @@ import IOHK.Certification.Persistence.API as X
   , getProfile
   , getProfileDApp
   , createRun
+  , getRun
   , updateFinishedRun
   , getRuns
   , withDb

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence/API.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence/API.hs
@@ -128,8 +128,13 @@ syncRun runId time= update runs
     (\run -> run ! #runId .== literal runId)
     (`with` [ #syncedAt := literal time ])
 
-createCertificate :: (MonadSelda m,MonadMask m) => UUID -> Text -> Text -> UTCTime -> m (Maybe Certification)
-createCertificate runId ipfsCID txId time = transaction $ do
+createCertificate :: (MonadSelda m,MonadMask m)
+                  => UUID
+                  -> IpfsCid
+                  -> TxId
+                  -> UTCTime
+                  -> m (Maybe Certification)
+createCertificate runId IpfsCid{..} TxId{..} time = transaction $ do
   result <- query $ do
     run <- select runs
     restrict (run ! #runId .== literal runId)
@@ -142,7 +147,7 @@ createCertificate runId ipfsCID txId time = transaction $ do
         (`with` [ #runStatus := literal Certified
                 , #syncedAt := literal time
                 ])
-      let cert = Certification runId ipfsCID txId time
+      let cert = Certification runId ipfsCid txId time
       _ <- insert certifications [cert]
       pure $ Just $ cert
     _ -> pure Nothing

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence/Structure.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence/Structure.hs
@@ -80,22 +80,23 @@ profileJSONPairs Profile{..} =
 instance SqlRow Profile
 
 data Certification = Certification
-  { certId :: ID Certification
+  { certRunId :: UUID
   , certReportContentId :: Text
+  , certTransactionId :: Text
   , certCreatedAt :: UTCTime
-  , certRunId :: UUID
   } deriving (Generic,Show)
 
 instance FromJSON Certification where
     parseJSON = withObject "Certification" $ \v -> Certification
-      <$> (pure def)
+      <$> v .: "runId"
       <*> v .: "reportContentId"
+      <*> v .: "transactionId"
       <*> v .: "createdAt"
-      <*> v .: "runId"
 
 instance ToJSON Certification where
   toJSON (Certification{..}) = object
       [ "reportContentId" .= certReportContentId
+      , "transactionId" .= certTransactionId
       , "createdAt" .= certCreatedAt
       , "runId" .= certRunId
       ]
@@ -109,6 +110,7 @@ instance ToSchema Certification where
       & type_ ?~ SwaggerObject
       & properties .~
           [ ("reportContentId", textSchema)
+          , ("transactionId", textSchema)
           , ("createdAt", utcSchema)
           , ("runId", uuidSchema)
           ]
@@ -277,9 +279,8 @@ runs = table "run"
 
 certifications :: Table Certification
 certifications = table "certification"
-  [ #certId :- primary
+  [ #certRunId :- primary
   , #certRunId :- foreignKey runs #runId
-  , #certRunId :- unique
   ]
 
 dapps :: Table DApp

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence/Structure.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence/Structure.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module IOHK.Certification.Persistence.Structure where
 
@@ -20,6 +21,12 @@ import Data.Aeson.Types
 import Data.Proxy
 import Data.Swagger hiding (Contact)
 import Control.Lens hiding ((.=),index)
+
+newtype IpfsCid = IpfsCid { ipfsCid :: Text}
+  deriving (ToJSON,FromJSON,Show )
+
+newtype TxId = TxId { txId :: Text}
+  deriving (ToJSON,FromJSON,Show,Read)
 
 data Profile = Profile
   { profileId :: ID Profile   -- TODO: do we need an internal id?

--- a/docker-compose.cardano.yml
+++ b/docker-compose.cardano.yml
@@ -1,0 +1,51 @@
+version: "3.5"
+
+services:
+  cardano-node:
+    image: inputoutput/cardano-node:1.35.4
+    environment:
+      NETWORK:
+      CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
+    volumes:
+      - node-${NETWORK}-db:/data
+      - node-ipc:/ipc
+    restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        compress: "true"
+        max-file: "10"
+        max-size: "50m"
+
+  cardano-wallet:
+    image: inputoutput/cardano-wallet:2022.12.14
+    volumes:
+      - wallet-${NETWORK}-db:/wallet-db
+      - node-ipc:/ipc
+    ports:
+      - 8090:8090
+    entrypoint: []
+    command: bash -c "
+        ([[ $$NETWORK == \"mainnet\" ]] && $$CMD --mainnet) ||
+        ($$CMD --testnet /config/${NETWORK}/genesis-byron.json)
+      "
+    environment:
+      CMD: "cardano-wallet serve --node-socket /ipc/node.socket --database /wallet-db --listen-address 0.0.0.0"
+      NETWORK:
+    restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        compress: "true"
+        max-file: "10"
+        max-size: "50m"
+
+volumes:
+  node-mainnet-db:
+  wallet-mainnet-db:
+  node-preprod-db:
+  wallet-preprod-db:
+  node-preview-db:
+  wallet-preview-db:
+  node-ipc:
+  node-config:

--- a/docker-files/wallet-container-instructions.md
+++ b/docker-files/wallet-container-instructions.md
@@ -1,0 +1,45 @@
+## 1. To manage cardano-node and cardano-wallet containers
+
+1.1 first to start containers run:
+
+```
+NETWORK=preprod docker-compose -f docker-compose.cardano.yml up
+```
+
+or as a dameon
+
+```
+NETWORK=preprod docker-compose -f docker-compose.cardano.yml up -d
+```
+
+## 2. create a wallet 
+
+```
+curl --request POST --url http://localhost:8090/v2/wallets \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "name": "test_cf_1",
+    "mnemonic_sentence": ["stock","horn","under","crime","acid","tell","repair","brain","shallow","dinosaur","candy","sight","memory","antenna","baby","truck","force","chuckle","elephant","unhappy","sentence","control","hold","camera"],
+    "passphrase": "test123456"
+}'
+```
+
+## 3. await to be synced (ready)
+```
+curl --url 'http://localhost:8090/v2/wallets/73857344a0cf884fe044abfe85660cc9a81f6366' | jq '.state.status'
+```
+
+
+# TIPS:
+
+## for checking the balance
+```
+curl --url 'http://localhost:8090/v2/wallets/73857344a0cf884fe044abfe85660cc9a81f6366' | jq '.balance.total.quantity'
+```
+
+## in order to stop the containers if you run it as daemon
+
+```
+NETWORK=preprod docker-compose -f docker-compose.cardano.yml down
+```
+

--- a/plutus-certification.cabal
+++ b/plutus-certification.cabal
@@ -60,6 +60,7 @@ library
     Plutus.Certification.Server
     Plutus.Certification.Local
     Plutus.Certification.GithubClient
+    Plutus.Certification.WalletClient
   other-modules:
     Paths_plutus_certification
     Plutus.Certification.API.Routes

--- a/src/Plutus/Certification/Server.hs
+++ b/src/Plutus/Certification/Server.hs
@@ -66,11 +66,9 @@ data CreateRunField
   = CreateRunRef !FlakeRefV1
   | CreateRunID !RunIDV1
 
-newtype IpfsCID = IpfsCid Text
-  deriving (ToJSON )
 data CreateCertificationField
   = CreateCertificationRunID !RunIDV1
-  | CreateCertificationIpfsCid !IpfsCID
+  | CreateCertificationIpfsCid !DB.IpfsCid
   | CreateCertificationTxResponse !Wallet.TxResponse
 
 data ServerEventSelector f where
@@ -210,7 +208,7 @@ server ServerCaps {..} wargs eb = NamedAPI
     (IPFS.UploadResponse ipfsCid _) <- maybe
       (throwError $ err403 { errBody = "Incompatible status for certification"})
       uploadToIpfs certResultM
-    addField ev (CreateCertificationIpfsCid (IpfsCid ipfsCid))
+    addField ev (CreateCertificationIpfsCid ipfsCid)
 
     -- create the certification object
     websiteUrl <- parseUrl website

--- a/src/Plutus/Certification/WalletClient.hs
+++ b/src/Plutus/Certification/WalletClient.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE BlockArguments            #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Plutus.Certification.WalletClient
+  ( TxResponse(..)
+  , Amount(..)
+  , WalletArgs(..)
+  , broadcastTransaction
+  ,CertificationMetadata(..)
+  ) where
+
+import Data.UUID
+import GHC.Generics
+import Data.Aeson
+import Data.Proxy
+import Network.HTTP.Client      hiding (Proxy)
+import Network.HTTP.Client.TLS
+import Servant.API
+import Servant.Client
+import Data.Text
+import Data.Aeson.QQ
+import Control.Monad.IO.Class
+
+data TxBody = forall a . (ToJSON a) => TxBody
+  { passphrase :: !Text
+  , address :: !Text
+  , metadata :: !a
+  }
+
+instance ToJSON TxBody where
+  toJSON (TxBody{..}) =
+    [aesonQQ| {
+        "passphrase": #{passphrase} ,
+        "payments": [
+            {
+                "address": #{address},
+                "amount": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            }
+        ],
+        "metadata": #{metadata}
+    } |]
+
+data Amount = Amount !Integer !Text deriving Show
+
+instance FromJSON Amount where
+  parseJSON = withObject "Amount" \o -> Amount
+    <$> o .: "quantity"
+    <*> o .: "unit"
+
+instance ToJSON Amount where
+  toJSON (Amount q u) = object [ "quantity" .= q  , "unit" .= u ]
+
+data TxResponse = TxResponse
+  { txRespAmount :: !Amount
+  , txRespId :: !Text
+  } deriving Show
+
+instance FromJSON TxResponse where
+  parseJSON = withObject "TxResponse" \o -> TxResponse
+    <$> o .: "amount"
+    <*> o .: "id"
+
+instance ToJSON TxResponse where
+  toJSON TxResponse{..}= object [ "amount" .= txRespAmount , "id" .= txRespId ]
+
+type API = "v2" :> "wallets"
+         :> Capture "wallet-id" Text
+         :> "transactions"
+         :> ReqBody '[JSON] TxBody
+         :> Verb 'POST 202 '[JSON] TxResponse
+
+data WalletArgs = WalletArgs
+  { walletId :: !Text
+  , walletAddress :: !Text
+  --TODO: this might not be safe to be passed as a
+  , walletPassphrase :: !Text
+  , walletAPIAddress :: !BaseUrl
+  } deriving Show
+
+data CertificationMetadata = CertificationMetadata
+  { crtmId :: !UUID
+  , crtmIpfsCid :: !Text
+  , crtmProjectName :: !Text
+  , crtmLink :: !(Maybe BaseUrl)
+  , crtmTwitter :: !(Maybe Text)
+  , crtmContractLink :: !URI
+  , crtmVersion :: !Text
+  } deriving Generic
+
+splitString :: Int -> Text -> Value
+splitString maxChars = toValue . chunksOf maxChars
+    where
+    toValue []     = toJSON ("" :: Text)
+    toValue (x:[]) = toJSON x
+    toValue xs     = toJSON xs
+
+split64 :: Text -> Value
+split64 = splitString 64
+
+instance ToJSON CertificationMetadata where
+  toJSON CertificationMetadata{..} =  object
+    [ "id" .= crtmId
+    , "ipfsCid" .= split64 crtmIpfsCid
+    , "projectName" .= split64 crtmProjectName
+    , "link" .= fmap (split64 . pack . showBaseUrl ) crtmLink
+    , "twitter" .= fmap split64 crtmTwitter
+    , "contractLink" .= split64 (pack $ show crtmContractLink)
+    , "version" .= split64 crtmVersion
+    ]
+
+
+broadcastTransaction :: (MonadIO m, ToJSON metadata)
+                     => WalletArgs
+                     -> metadata
+                     -> m (Either ClientError TxResponse)
+broadcastTransaction WalletArgs{..} metadata = liftIO $ do
+  manager' <- newManager (if baseUrlScheme walletAPIAddress == Https then tlsManagerSettings else defaultManagerSettings)
+  let settings  = (mkClientEnv manager' walletAPIAddress)
+  let broadcastTx = client (Proxy :: Proxy API)
+  let body = TxBody walletPassphrase walletAddress [aesonQQ| { "0": #{ metadata }} |]
+
+  runClientM (broadcastTx walletId body ) settings
+

--- a/src/Plutus/Certification/WalletClient.hs
+++ b/src/Plutus/Certification/WalletClient.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Plutus.Certification.WalletClient
   ( TxResponse(..)
@@ -26,6 +27,7 @@ import Servant.Client
 import Data.Text
 import Data.Aeson.QQ
 import Control.Monad.IO.Class
+import IOHK.Certification.Persistence
 
 data TxBody = forall a . (ToJSON a) => TxBody
   { passphrase :: !Text
@@ -61,7 +63,7 @@ instance ToJSON Amount where
 
 data TxResponse = TxResponse
   { txRespAmount :: !Amount
-  , txRespId :: !Text
+  , txRespId :: !TxId
   } deriving Show
 
 instance FromJSON TxResponse where
@@ -88,7 +90,7 @@ data WalletArgs = WalletArgs
 
 data CertificationMetadata = CertificationMetadata
   { crtmId :: !UUID
-  , crtmIpfsCid :: !Text
+  , crtmIpfsCid :: !IpfsCid
   , crtmProjectName :: !Text
   , crtmLink :: !(Maybe BaseUrl)
   , crtmTwitter :: !(Maybe Text)
@@ -109,7 +111,7 @@ split64 = splitString 64
 instance ToJSON CertificationMetadata where
   toJSON CertificationMetadata{..} =  object
     [ "id" .= crtmId
-    , "ipfsCid" .= split64 crtmIpfsCid
+    , "ipfsCid" .= split64 (crtmIpfsCid.ipfsCid)
     , "projectName" .= split64 crtmProjectName
     , "link" .= fmap (split64 . pack . showBaseUrl ) crtmLink
     , "twitter" .= fmap split64 crtmTwitter

--- a/src/Plutus/Certification/Web3StorageClient.hs
+++ b/src/Plutus/Certification/Web3StorageClient.hs
@@ -10,7 +10,7 @@ module Plutus.Certification.Web3StorageClient where
 import Data.Aeson
 import Network.HTTP.Client      hiding (Proxy)
 import Network.HTTP.Client.TLS
-import Control.Monad.IO.Class 
+import Control.Monad.IO.Class
 import Network.HTTP.Types.Header
 import Data.ByteString.Char8 as BS hiding (hPutStrLn)
 import Servant.Client.Core hiding (responseBody,Response,DecodeFailure)
@@ -19,8 +19,8 @@ import Servant.API hiding (addHeader)
 import Network.HTTP.Types.Status
 import Network.HTTP.Client.MultipartFormData
 import System.IO.Temp
-
-import qualified Data.ByteString.Lazy.Char8 as BSL 
+import IOHK.Certification.Persistence
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 import GHC.IO.Handle
 type instance AuthClientData (AuthProtect "api-key") = ByteString
@@ -29,7 +29,7 @@ addAuth :: ByteString -> AuthenticatedRequest (AuthProtect "api-key")
 addAuth = flip mkAuthenticatedRequest (\v -> addHeader hAuthorization ("Bearer " <> BS.unpack v))
 
 data UploadResponse = UploadResponse
-  { uploadCid :: Text
+  { uploadCid :: IpfsCid
   , uploadCarCid :: Text
   } deriving Show
 


### PR DESCRIPTION
- adding support for `cardano-wallet` transaction signing
- adding a docker-compose separated file for `cardano-node` and `cardano-wallet`
- finishing the `create-certificate` route by adding the capability of creating the certification metadata and broadcasting the transaction onchain
- add `transaction-id` into db