### PR TITLE
fix: pin plutus apps version

### DIFF
--- a/dapps-certification-helpers/src/IOHK/Certification/Actions.hs
+++ b/dapps-certification-helpers/src/IOHK/Certification/Actions.hs
@@ -63,7 +63,7 @@ generateFlake backend addLogEntry flakeref output = withEvent backend GenerateFl
     hPutStrLn h "  inputs = {"
     hPutStr   h "    repo = " >> writeNix h lock >> hPutStrLn h ";"
     hPutStrLn h "    plutus-apps = {"
-    hPutStrLn h "      url = \"github:input-output-hk/plutus-apps\";"
+    hPutStrLn h "      url = \"github:input-output-hk/plutus-apps/1651d36a0f6458e7d2326d57dbc1baa00034d70d\";"
     hPutStrLn h "      flake = false;"
     hPutStrLn h "    };"
     hPutStrLn h "    dapps-certification = {"


### PR DESCRIPTION
- due to some modifications within `plutus-apps` project the current dapp certification examples are not compatible anymore. So, we temporarily choose an older commit version 
- fix decoding for GitHub API response when choosing a specific commit