### PR TITLE
fix: update docker-ws definition for the wallet integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,6 @@ docker-compose.yml
 Dockerfile.web
 Dockerfile.ws
 docker-files/wallet-container-instructions.md
+react-web/coverage
+react-web/node_modules
+react-web/build

--- a/Dockerfile.ws
+++ b/Dockerfile.ws
@@ -10,6 +10,6 @@ WORKDIR /
 RUN rm -rf dapps-certification/
 
 #ENTRYPOINT [ "/bin/sh" ]
-CMD [ "plutus-certification","--local" ]
+CMD [ "plutus-certification","--local", "--wallet-id", "73857344a0cf884fe044abfe85660cc9a81f6366", "--wallet-address", "addr_test1qphgqts20fhx0yx7ug42xehcnryukchy5k7hpaksgxax2fzt5w2gu33s8wrw3c9tjs97dr5pulsvf39e56v7c9ar39asptcrtp", "--wallet-passphrase", "test123456", "--wallet-url", "http://host.docker.internal:8090" ]
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.ws
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "9671:9671"
   plutus-certification-web:

--- a/docker-files/nix.conf
+++ b/docker-files/nix.conf
@@ -1,5 +1,5 @@
 trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-substituters        = https://cache.nixos.org/ https://cache.iog.io
+substituters        = https://hydra.iohk.io https://cache.nixos.org/ https://cache.iog.io
 
 build-users-group = nixbld
 


### PR DESCRIPTION
fix `Dockerfile.ws` because of the new wallet-integration

To test the PR, run:
```sh
#to build the container
docker-compose --verbose up plutus-certification-ws
#and then to run it
docker-compose up  plutus-certification-ws
```