### PR TITLE
chore: change metadata key for broadcasting a certificate

### DIFF
--- a/src/Plutus/Certification/TransactionBroadcaster.hs
+++ b/src/Plutus/Certification/TransactionBroadcaster.hs
@@ -75,7 +75,7 @@ createCertification eb wargs profileId rid@RunID{..} = withEvent eb CreateCertif
                     (profile.twitter) uri dappVersion
 
   -- broadcast the certification
-  tx@Wallet.TxResponse{..} <- Wallet.broadcastTransaction wargs certificate
+  tx@Wallet.TxResponse{..} <- Wallet.broadcastTransaction wargs 1304 certificate
     >>= eitherToError show
   addField ev (CreateCertificationTxResponse tx)
 

--- a/src/Plutus/Certification/WalletClient.hs
+++ b/src/Plutus/Certification/WalletClient.hs
@@ -136,14 +136,17 @@ mkSettings walletAPIAddress = liftIO $ do
   manager' <- newManager (if baseUrlScheme walletAPIAddress == Https then tlsManagerSettings else defaultManagerSettings)
   pure (mkClientEnv manager' walletAPIAddress)
 
+type MetadataKey = Int
 broadcastTransaction :: (MonadIO m, ToJSON metadata)
                      => WalletArgs
+                     -> MetadataKey
                      -> metadata
                      -> m (Either ClientError TxResponse)
-broadcastTransaction WalletArgs{..} metadata = liftIO $ do
+broadcastTransaction WalletArgs{..} metadataKey metadata = liftIO $ do
   settings <- mkSettings walletAPIAddress
   let broadcastTx :<|> _ = mkClient walletId
-  let body = TxBody walletPassphrase walletAddress [aesonQQ| { "0": #{ metadata }} |]
+      metadataKeyStr = show metadataKey
+  let body = TxBody walletPassphrase walletAddress [aesonQQ| { $metadataKeyStr: #{ metadata }} |]
   runClientM (broadcastTx body ) settings
 
 getTransactionList :: (MonadIO m)


### PR DESCRIPTION
- changing the metadata key for a certificate from 0 to 1304
- make the broadcasting key a parameter for the `broadcastTransaction` function in order to be flexible in other contexts (eg. broadcast the transaction for assigning different application wallet addresses to a profile)