### PR TITLE
chore: move the generation of gh-token on backend (PLT-5769)

### DIFF
--- a/react-web/src/pages/userProfile/slices/repositoryAccess.slice.ts
+++ b/react-web/src/pages/userProfile/slices/repositoryAccess.slice.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { getRepoAccess, postExternal } from "api/api";
+import { getRepoAccess, postExternal,fetchData } from "api/api";
+import { AxiosResponse } from "axios";
 
 interface RepoAccessState {
     verifying: boolean,
@@ -28,10 +29,9 @@ export const verifyRepoAccess = createAsyncThunk(
   );
 
 
-export const getUserAccessToken = createAsyncThunk("getUserAccessToken", async(payload: any, {rejectWithValue}) => {
-    const response: any = postExternal.post("https://github.com/login/oauth/access_token" + payload.queryParams)
-    return response
-})  
+export const getUserAccessToken = createAsyncThunk("getUserAccessToken", async(payload: any) => 
+    fetchData.post<any,AxiosResponse<{access_token: string}>,any>(`/github/access-token/${payload.code}`)
+)
 
 export const repoAccessSlice = createSlice({
   name: "repoAccess",
@@ -70,7 +70,7 @@ export const repoAccessSlice = createSlice({
         state.accessToken = ""
       })
       .addCase(getUserAccessToken.pending, (state, actions) => {
-        
+
       })
       .addCase(getUserAccessToken.fulfilled, (state, actions) => { console.log('payload-', actions.payload)
         const token: string = actions.payload?.data.access_token

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -76,10 +76,15 @@ data Args = Args
   , host :: !HostPreference
   , backend :: !Backend
   , wallet :: !WalletArgs
-  , githubToken :: !(Maybe GitHubAccessToken)
   , auth :: !AuthMode
   , signatureTimeout :: !Seconds
   , useWhitelist :: !Bool
+  , github :: !GitHubArgs
+  }
+
+data GitHubArgs = GitHubArgs
+  { accessToken :: !(Maybe GitHubAccessToken)
+  , credentials :: !(Maybe GitHubCredentials)
   }
 
 baseUrlReader :: ReadM BaseUrl
@@ -126,7 +131,6 @@ argsParser =  Args
       )
   <*> (localParser <|> ciceroParser)
   <*> walletParser
-  <*> optional gitHubAccessTokenParser
   <*> (jwtArgsParser <|> plainAddressAuthParser)
   <*> option auto
       ( long "signature-timeout"
@@ -137,6 +141,8 @@ argsParser =  Args
       )
   <*> switch
       ( long "use-whitelist" <> help "use the whitelist for authentication" )
+  <*> githubArgsParser
+
 
 data AuthMode = JWTAuth JWTArgs | PlainAddressAuth
 
@@ -162,6 +168,25 @@ jwtArgsParser =  JWTAuth <$> (JWTArgs
       <> showDefault
       <> Opts.value defaultJWTExpiration
       ))
+githubArgsParser :: Parser GitHubArgs
+githubArgsParser = GitHubArgs
+  <$> optional gitHubAccessTokenParser
+  <*> optional (GitHubCredentials <$> gitHubClientIdParser <*> gitHubClientSecretParser)
+
+gitHubClientIdParser :: Parser Text
+gitHubClientIdParser = Text.pack <$> strOption
+  ( long "github-client-id"
+ <> metavar "GITHUB_CLIENT_ID"
+ <> help "GitHub OAuth client ID"
+  )
+
+gitHubClientSecretParser :: Parser Text
+gitHubClientSecretParser = Text.pack <$> strOption
+  ( long "github-client-secret"
+ <> metavar "GITHUB_CLIENT_SECRET"
+ <> help "GitHub OAuth client secret"
+  )
+
 walletParser :: Parser WalletArgs
 walletParser = WalletArgs
   <$> option str
@@ -366,8 +391,10 @@ main = do
         (\r -> swaggerSchemaUIServer (documentation args.auth) :<|> server (serverArgs args caps r eb whitelist))
   exitFailure
   where
-  serverArgs args caps r eb = ServerArgs
-    caps (args.wallet) args.githubToken (jwtArgs args.auth) (be r eb) (args.signatureTimeout)
+  serverArgs args caps r eb whiteList =
+    ServerArgs caps (args.wallet) args.github.accessToken (jwtArgs args.auth) (be r eb) 
+        (args.signatureTimeout) whiteList args.github.credentials 
+
   jwtArgs PlainAddressAuth = Nothing
   jwtArgs (JWTAuth args) = Just args
   documentation PlainAddressAuth = swaggerJson

--- a/src/Plutus/Certification/API/Routes.hs
+++ b/src/Plutus/Certification/API/Routes.hs
@@ -37,7 +37,7 @@ import Data.Time
 import Data.Proxy
 import Plutus.Certification.WalletClient
 import Control.Lens hiding ((.=))
-import Plutus.Certification.GitHubClient (RepositoryInfo)
+import Plutus.Certification.GitHubClient (RepositoryInfo,AccessTokenGenerationResponse)
 import Control.Arrow (ArrowChoice(left))
 import GHC.TypeLits
 import Servant.Client (BaseUrl)
@@ -143,6 +143,15 @@ type GitHubRoute = "repo"
   :> Servant.Header "Authorization" ApiGitHubAccessToken
   :> Get '[JSON] RepositoryInfo
 
+type GenerateGitHubTokenRoute = "github" :> "access-token"
+  :> Description "Generate a github access token"
+  :> Capture "code" Text
+  :> Post '[JSON] AccessTokenGenerationResponse
+
+type GetGitHubClientId = "github" :> "client-id"
+  :> Description "Get the application client id"
+  :> Get '[JSON] Text
+
 type LoginRoute = "login"
   :> Description "Get a jwt token based on the provided credentials"
   :> ReqBody '[JSON] LoginBody
@@ -151,6 +160,7 @@ type LoginRoute = "login"
 type ServerTimestamp = "server-timestamp"
   :> Description "Get the current server timestamp"
   :> Get '[JSON] Integer
+
 
 newtype ApiGitHubAccessToken = ApiGitHubAccessToken { unApiGitHubAccessToken :: GitHubAccessToken }
   deriving (Generic)
@@ -236,6 +246,8 @@ data NamedAPI (auth :: Symbol) mode = NamedAPI
   , getRepositoryInfo :: mode :- GitHubRoute
   , login :: mode :- LoginRoute
   , serverTimestamp :: mode :- ServerTimestamp
+  , generateGitHubToken :: mode :- GenerateGitHubTokenRoute
+  , getGitHubClientId :: mode :- GetGitHubClientId
   } deriving stock Generic
 
 data DAppBody = DAppBody

--- a/src/Plutus/Certification/API/Swagger.hs
+++ b/src/Plutus/Certification/API/Swagger.hs
@@ -40,6 +40,8 @@ type UnnamedApi (auth :: Symbol)
   :<|> GetBalanceRoute auth
   :<|> WalletAddressRoute
   :<|> GitHubRoute
+  :<|> GenerateGitHubTokenRoute
+  :<|> GetGitHubClientId
 
 type UnnamedApiWithLogin (auth :: Symbol)
      = UnnamedApi auth

--- a/src/Plutus/Certification/Server/Internal.hs
+++ b/src/Plutus/Certification/Server/Internal.hs
@@ -32,7 +32,6 @@ import Control.Exception hiding (Handler)
 import Plutus.Certification.WalletClient (WalletAddress)
 
 import qualified IOHK.Certification.Persistence as DB
-import Control.Lens (only)
 
 -- | Capabilities needed to run a server for 'API'
 data ServerCaps m r = ServerCaps
@@ -58,6 +57,9 @@ data GetRepoInfoField
   = GetRepoInfoOwner !Text
   | GetRepoInfoRepo !Text
 
+type Error = String
+newtype GenerateGitHubTokenField = GenerateGitHubTokenError Error
+
 data ServerEventSelector f where
   Version :: ServerEventSelector Void
   WalletAddress :: ServerEventSelector Void
@@ -72,6 +74,8 @@ data ServerEventSelector f where
   StartCertification :: ServerEventSelector StartCertificationField
   Login :: ServerEventSelector WalletAddress
   ServerTimestamp :: ServerEventSelector Void
+  GenerateGitHubToken :: ServerEventSelector GenerateGitHubTokenField
+  GetGitHubClientId :: ServerEventSelector Void
 
 renderServerEventSelector :: RenderSelectorJSON ServerEventSelector
 renderServerEventSelector Version = ("version", absurd)
@@ -84,6 +88,10 @@ renderServerEventSelector GetProfileBalance = ("get-profile-balance", renderProf
 renderServerEventSelector GetCertification = ("get-certification", renderRunIDV1)
 renderServerEventSelector Login = ("login", \address' -> ("user-address", toJSON address'))
 renderServerEventSelector ServerTimestamp = ("server-timestamp", absurd)
+renderServerEventSelector GenerateGitHubToken = ("generate-github-token", \
+    (GenerateGitHubTokenError err) -> ("error", toJSON err)
+  )
+renderServerEventSelector GetGitHubClientId = ("get-github-client-id", absurd)
 
 renderServerEventSelector CreateRun = ("create-run", \case
     CreateRunRef fr -> ("flake-reference", toJSON $ uriToString id fr.uri "")


### PR DESCRIPTION
In the past, we temporarily exposed the application's GitHub credentials on the Frontend side to speed up the development process. This PR is moving all that `github-token-access` generation on the server side.

The original plan was to completely hide the GitHub access token from the client side. I still think that would be a safer way to go but at this moment the implication of that modifications might cost us some time.

@amnambiar could you please take a look at least at the react-web modifications?

UPDATE: momentarily we won't be able to test this with the current server instance (excuse.ro)  because the service runs other targeted branch. Once we approve the previous PR's we will be able to expose this BE modifications too 
