### PR TITLE
Updating to be compatible with plutus-apps version 1.2

### DIFF
--- a/dapps-certification-helpers/data/Certify.hs
+++ b/dapps-certification-helpers/data/Certify.hs
@@ -27,7 +27,7 @@ import "uuid" Data.UUID.V4
 taskName :: CertificationTask -> I.CertificationTaskName
 taskName UnitTestsTask = I.UnitTestsTask
 taskName StandardPropertyTask = I.StandardPropertyTask
-taskName DoubleSatisfactionTask = I.DoubleSatisfactionTask
+-- taskName DoubleSatisfactionTask = I.DoubleSatisfactionTask
 taskName NoLockedFundsTask = I.NoLockedFundsTask
 taskName NoLockedFundsLightTask = I.NoLockedFundsLightTask
 taskName CrashToleranceTask = I.CrashToleranceTask

--- a/dapps-certification-helpers/data/outputs.nix
+++ b/dapps-certification-helpers/data/outputs.nix
@@ -10,7 +10,7 @@
 
   project = origProject.appendModule ({ lib, ... }: {
     cabalProject = lib.mkForce (builtins.readFile "${modifiedCabalProject}/cabal.project");
-    cabalProjectLocal = lib.mkForce (origProject.args.cabalProjectLocal + ''
+    cabalProjectLocal = lib.mkForce ((x : if isNull x then "" else x)(origProject.args.cabalProjectLocal) + ''
       source-repository-package
         type: git
         location: https://github.com/input-output-hk/plutus-apps

--- a/dapps-certification-helpers/src/IOHK/Certification/Actions.hs
+++ b/dapps-certification-helpers/src/IOHK/Certification/Actions.hs
@@ -66,7 +66,7 @@ generateFlake backend addLogEntry ghAccessTokenM flakeref output = withEvent bac
     hPutStrLn h "  inputs = {"
     hPutStr   h "    repo = " >> writeNix h lock >> hPutStrLn h ";"
     hPutStrLn h "    plutus-apps = {"
-    hPutStrLn h "      url = \"github:input-output-hk/plutus-apps/1651d36a0f6458e7d2326d57dbc1baa00034d70d\";"
+    hPutStrLn h "      url = \"github:input-output-hk/plutus-apps/68efca7eda4afd1c14698adf697d70acb5a489e2\";"
     hPutStrLn h "      flake = false;"
     hPutStrLn h "    };"
     hPutStrLn h "    dapps-certification = {"

--- a/dapps-certification-interface/src/IOHK/Certification/Interface.hs
+++ b/dapps-certification-interface/src/IOHK/Certification/Interface.hs
@@ -18,7 +18,7 @@ import Data.Char (isAlphaNum)
 data CertificationTaskName
   = UnitTestsTask
   | StandardPropertyTask
-  | DoubleSatisfactionTask
+--   | DoubleSatisfactionTask
   | NoLockedFundsTask
   | NoLockedFundsLightTask
   | CrashToleranceTask
@@ -34,7 +34,7 @@ instance ToSchema CertificationTaskName where
 renderTask :: CertificationTaskName -> Either String Text
 renderTask UnitTestsTask = Right "unit-tests"
 renderTask StandardPropertyTask = Right "standard-property"
-renderTask DoubleSatisfactionTask = Right "double-satisfaction"
+-- renderTask DoubleSatisfactionTask = Right "double-satisfaction"
 renderTask NoLockedFundsTask = Right "no-locked-funds"
 renderTask NoLockedFundsLightTask = Right "no-locked-funds-light"
 renderTask CrashToleranceTask = Right "crash-tolerance"
@@ -58,7 +58,7 @@ instance FromJSON CertificationTaskName where
       known = flip (withText "CertificationTaskName") v \nm ->
         if | nm == "unit-tests" -> pure UnitTestsTask
            | nm == "standard-property" -> pure StandardPropertyTask
-           | nm == "double-satisfaction" -> pure DoubleSatisfactionTask
+        --    | nm == "double-satisfaction" -> pure DoubleSatisfactionTask
            | nm == "no-locked-funds" -> pure NoLockedFundsTask
            | nm == "no-locked-funds-light" -> pure NoLockedFundsLightTask
            | nm == "crash-tolerance" -> pure CrashToleranceTask


### PR DESCRIPTION
ChangeLog:

- Bumping version of plutus-apps to v1.2
- Temporarily disabling testing for double satisfaction as it is not supported by v1.2
-  Adding function to allow for a null cabal project local file

Tested with: 

`nix run github:Ali-Hill/dapps-certification#dapps-certification-helpers:exe:generate-flake -- github:Ali-Hill/minimal-escrow/7acf069dd736cbe558c4a8304de49c6594e61a25 /tmp/s4`

`nix run github:Ali-Hill/dapps-certification#dapps-certification-helpers:exe:build-flake -- /tmp/s4`

Note that the main branch of Ali-Hill/dapps-certification has an additional change to point the flake.nix to run the fork. 