### PR TITLE
Add system to outputs.nix

### DIFF
--- a/dapps-certification-helpers/data/outputs.nix
+++ b/dapps-certification-helpers/data/outputs.nix
@@ -1,5 +1,5 @@
 { plutus-apps, dapps-certification, repo, ... }: let
-  origProject = repo.iog.dapp;
+  origProject = repo.iog.x86_64-linux.dapp;
 
   inherit (origProject) pkgs;
 


### PR DESCRIPTION
This allows for the tool to work with the iogx version of the minimal examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- New Feature: Introduced a new function `mkCertify` that allows generation of the `certify` executable for different systems.
- Refactor: Updated `defaultPackage` to include separate entries for `x86_64-linux` and `x86_64-darwin` systems, enhancing system compatibility.
- Refactor: Modified the value of `origProject` from `repo.iog.dapp` to `repo.iog.x86_64-linux.dapp`, improving project specificity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->