### PR TITLE
feat/change-profile-fields ( PLT-6187 , PLT-7408)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Makefile
 .pre-commit-config.yaml
 *.ignore.*
 todo.txt
+*.pir

--- a/dapps-certification-interface/dapps-certification-interface.cabal
+++ b/dapps-certification-interface/dapps-certification-interface.cabal
@@ -6,6 +6,6 @@ maintainer:         shea.levy@iohk.io
 
 library
     exposed-modules:  IOHK.Certification.Interface
-    build-depends:    base, aeson, text, swagger2
+    build-depends:    base, aeson, text, swagger2, lens
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/dapps-certification-persistence/dapps-certification-persistence.cabal
+++ b/dapps-certification-persistence/dapps-certification-persistence.cabal
@@ -12,6 +12,7 @@ library
                     , IOHK.Certification.Persistence.Structure.Certification
                     , IOHK.Certification.Persistence.Structure.Run
                     , IOHK.Certification.Persistence.Structure.Profile
+                    , IOHK.Certification.Persistence.Pattern
     build-depends: base
                  , selda
                  , selda-sqlite
@@ -23,5 +24,9 @@ library
                  , swagger2
                  , lens
                  , containers
+                 , raw-strings-qq
+                 , regex-tdfa
+
+                 , dapps-certification-interface
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence.hs
@@ -3,6 +3,13 @@ module IOHK.Certification.Persistence
   , MonadSelda
   ) where
 import Database.Selda
+
+import           IOHK.Certification.Interface  as X
+  ( GitHubAccessToken(..)
+  , GitHubAccessTokenType(..)
+  , ghAccessTokenPattern
+  )
+
 import IOHK.Certification.Persistence.Structure.Run as X
   ( Run(..)
   , Status(..)
@@ -16,6 +23,7 @@ import IOHK.Certification.Persistence.Structure.Certification as X
 import IOHK.Certification.Persistence.Structure as X
   ( DApp(..)
   , ProfileDTO(..)
+  , DAppDTO(..)
   , createTables
   , IpfsCid(..)
   , TxId(..)
@@ -33,9 +41,9 @@ import Database.Selda as X
   )
 import IOHK.Certification.Persistence.Structure.Profile as X
   ( ProfileId
-  , authors
   , Profile(..)
   )
+import IOHK.Certification.Persistence.Pattern as X
 import IOHK.Certification.Persistence.Structure.Subscription as X
   ( Subscription(..)
   , SubscriptionId

--- a/dapps-certification-persistence/src/IOHK/Certification/Persistence/Pattern.hs
+++ b/dapps-certification-persistence/src/IOHK/Certification/Persistence/Pattern.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE DeriveDataTypeable   #-}
+
+
+{-# LANGUAGE ScopedTypeVariables       #-}
+
+
+module IOHK.Certification.Persistence.Pattern
+( PatternedText(getPatternedText)
+, Twitter
+, LinkedIn
+, Website
+, Email
+, ProfileWalletAddress
+, mkPatternedText
+, match
+, getPattern
+) where
+
+import           Data.Text
+import           Control.Lens         hiding (index, (.=))
+import           Data.Aeson
+import           Data.Proxy
+import           Data.Swagger         hiding (Contact)
+import           Database.Selda
+import           Database.Selda.SqlType
+import           Control.Exception ( throw)
+import           GHC.TypeLits
+import           Data.Data
+
+import qualified Data.Swagger.Lens as SL
+import qualified Text.Regex.TDFA as TDFA
+
+--------------------------------------------------------------------------------
+-- | PatternedText
+
+newtype PatternedText n p = MkUnsafePatternedText { getPatternedText :: Text }
+                          deriving (Eq,Ord,Data)
+
+mkPatternedText :: forall p n. KnownSymbol p => Text -> Either String (PatternedText n p)
+mkPatternedText t = if match (pack labelP) t
+  then Right $ MkUnsafePatternedText t
+  else Left $ "Invalid value for pattern " ++ labelP
+  where
+  labelP = symbolVal (Proxy :: Proxy p)
+
+instance ToJSON (PatternedText n p) where
+  toJSON (MkUnsafePatternedText t) = String t
+
+instance (KnownSymbol n,KnownSymbol p) => FromJSON (PatternedText n p) where
+  parseJSON = withText labelN $ \t -> case mkPatternedText t of
+      Right value -> pure value
+      Left str -> fail str
+    where
+    labelN = symbolVal (Proxy :: Proxy n)
+
+instance (KnownSymbol n,KnownSymbol p) => SqlType (PatternedText n p) where
+  mkLit (MkUnsafePatternedText t) = LCustom TText (LText t)
+  sqlType _ = TText
+  fromSql (SqlString t) = case mkPatternedText t of
+    Right value -> value
+    Left str -> throw $ userError $ "fromSql: " ++ str
+  fromSql v = throw $ userError $ "fromSql: expected SqlString, got " ++ show v
+  defaultValue = throw $ userError $ labelN ++ " : no default value"
+    where
+    labelN = symbolVal (Proxy :: Proxy n)
+
+instance (KnownSymbol n,KnownSymbol p) => ToSchema (PatternedText n p) where
+  declareNamedSchema _ = do
+    return $ NamedSchema (Just labelN) $ mempty
+      & type_ ?~ SwaggerString
+      & SL.pattern ?~ labelP
+    where
+    labelP = pack $ symbolVal (Proxy :: Proxy p)
+    labelN = pack $ symbolVal (Proxy :: Proxy n)
+
+instance Show (PatternedText n p) where
+  show (MkUnsafePatternedText t) = show t
+
+getPattern :: forall n p. (KnownSymbol p) => Proxy (PatternedText n p) -> Text
+getPattern _ = pack $ symbolVal (Proxy :: Proxy p)
+
+match :: Text -> Text -> Bool
+match p val= val TDFA.=~ p
+
+{-
+
+>>> pattern = "^(https?:\\/\\/)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,255}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#()?&\\/\\/=]*)$"
+
+>>> match pattern "http://peY.com"
+Nothing
+
+>>> match' pattern "http://peY.com"
+True
+
+-}
+
+--------------------------------------------------------------------------------
+-- | Useful aliases
+
+
+type Twitter = PatternedText "Twitter"
+  "^[A-Za-z0-9_]{1,15}$"
+
+type LinkedIn = PatternedText "LinkedIn"
+  "^(http(s)?:\\/\\/)?([\\w]+\\.)?linkedin\\.com\\/(pub|in|profile|company)\\/([a-zA-Z0-9_-]+)$"
+
+type Email = PatternedText "Email" "^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-_]+\\.[A-Za-z]{2,64}$"
+
+type Website = PatternedText "Website"
+  "^(https?:\\/\\/)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,255}\\.[a-z]{2,6}(\\b([-a-zA-Z0-9@:%_\\+.~#()?&\\/\\/=]*))?$"
+type ProfileWalletAddress = PatternedText "ProfileWalletAddress"
+  "^(addr_test1|addr1|stake|stake_test1)[a-zA-Z0-9]{53,}$"

--- a/plutus-certification.cabal
+++ b/plutus-certification.cabal
@@ -50,10 +50,10 @@ library
     temporary,
     jwt ^>=0.11.0,
     unordered-containers,
-    regex-compat,
     vector,
     http-conduit,
     cryptonite,
+    insert-ordered-containers,
 
     dapps-certification-signature-verification,
     dapps-certification-persistence,
@@ -143,7 +143,6 @@ executable plutus-certification-client
     http-types ^>= 0.12.3,
     dapps-certification-helpers,
     base16-bytestring,
-    regex-compat,
     plutus-certification
   main-is: Main.hs
   hs-source-dirs: client
@@ -155,7 +154,12 @@ test-suite plutus-certification-test
   hs-source-dirs: test
   other-modules:
     ProfileWalletSpec
+    PatternSpec
+    JSONSpec
     ProfileWallet.Data
+    Instances.Persistence
+    Utils.JSON
+
   build-depends:
       base >= 4.14.3 && < 4.18
     , hspec
@@ -164,4 +168,7 @@ test-suite plutus-certification-test
     , dapps-certification-signature-verification
     , text
     , raw-strings-qq
+    , QuickCheck
     , aeson
+    , aeson-pretty
+    , bytestring

--- a/src/Plutus/Certification/API.hs
+++ b/src/Plutus/Certification/API.hs
@@ -10,10 +10,24 @@ import Plutus.Certification.Internal as X
   )
 import qualified IOHK.Cicero.API.Run as Cicero.Run (RunLog(..))
 
+import IOHK.Certification.Persistence as X
+  ( Profile(..)
+  , DApp(..)
+  , ProfileDTO(..)
+  , ProfileWalletAddress
+  , LinkedIn
+  , Website
+  , Email
+  , Twitter
+  , fromId
+  , toId
+  , PatternedText(..)
+  , mkPatternedText
+  , match
+  )
+
 import Plutus.Certification.API.Routes as X
   ( API
-  , Twitter(..)
-  , LinkedIn(..)
   , NamedAPI(..)
   , VersionV1(..)
   , RunIDV1(..)
@@ -24,12 +38,9 @@ import Plutus.Certification.API.Routes as X
   , CertifyingStatus(..)
   , IncompleteRunStatus(..)
   , KnownActionType(..)
-  , ProfileBody(..)
-  , DAppBody(..)
   , ApiGitHubAccessToken(..)
   , LoginBody(..)
-  , isTwitterValid
-  , linkedInProfilePattern
+  , ProfileBody(..)
   )
 import Plutus.Certification.API.Swagger as X
   ( swaggerJson

--- a/src/Plutus/Certification/Metadata/Types.hs
+++ b/src/Plutus/Certification/Metadata/Types.hs
@@ -241,6 +241,7 @@ instance FromJSON CertificationType where
       _ -> fail "action must be AUDIT or CERTIFY"
     certificateIssuer <- o .: "certificateIssuer"
     pure $ CertificationType{..}
+
 data PhantomAction
 
 instance ToSchema PhantomAction where

--- a/src/Plutus/Certification/Server.hs
+++ b/src/Plutus/Certification/Server.hs
@@ -4,7 +4,6 @@ module Plutus.Certification.Server (module X) where
 import Plutus.Certification.Server.Instance as X
 import Plutus.Certification.Server.Internal as X
   ( ServerCaps(..)
-  , UserAddress(..)
   , ServerEventSelector(..)
   , renderServerEventSelector
   , ensureProfile

--- a/test/Instances/Persistence.hs
+++ b/test/Instances/Persistence.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE FlexibleInstances     #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Instances.Persistence where
+
+import Test.QuickCheck
+import IOHK.Certification.Persistence
+import Plutus.Certification.API
+import Control.Monad (replicateM)
+import Data.Text
+import GHC.TypeLits (KnownSymbol)
+import Debug.Trace
+
+--------------------------------------------------------------------------------
+-- | GitHubAccessToken
+
+genGHSuffix :: Gen Text
+genGHSuffix = pack <$> replicateM 36 (elements "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+
+instance Arbitrary GitHubAccessTokenType where
+  arbitrary = elements [OAuthToken, UserToServerToken, ServerToServerToken, RefreshToken]
+
+instance Arbitrary GitHubAccessToken where
+  arbitrary = GitHubAccessToken
+    <$> arbitrary
+    <*> genGHSuffix
+
+-- between 1 and 15 characters, alphanumeric and underscore
+genTwitterAccount :: Gen Text
+genTwitterAccount = do
+  length' <- choose (1, 15)
+  pack <$> replicateM length' (elements "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_")
+
+
+instance Arbitrary Twitter where
+  arbitrary = genPatternedTextWith genTwitterAccount
+
+genPatternedTextWith :: (KnownSymbol n, KnownSymbol p) => Gen Text -> Gen (PatternedText n p)
+genPatternedTextWith g = do
+  text' <- g
+  case mkPatternedText text' of
+    Right b -> pure b
+    Left s -> traceError "genPatternedTextWith" s (show text')
+
+traceError :: [Char] -> [Char] -> [Char] -> a
+traceError propS err info =
+  trace ("\n\tERROR "++ propS ++ ":\n\t" ++ err ++ "\n" ++ info ++ "\n\n\n") (error "error")
+
+genCardanoAddress :: Gen Text
+genCardanoAddress = do
+  prefix <- elements ["addr_test1", "addr1", "stake", "stake_test1"]
+  length' <- choose (53, 98)
+  address' <- replicateM length' (elements "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+  return $ pack $ prefix ++ address'
+
+instance Arbitrary ProfileWalletAddress where
+  arbitrary = genPatternedTextWith genCardanoAddress
+
+genWebsite :: Gen Text
+genWebsite = do
+  prefix <- elements ["https://", "http://"]
+
+  domain <- genFullDomain
+
+  partsLen :: Int <- choose (1,2)
+  parts  <- replicateM partsLen genPart
+  let path = Prelude.foldl (\acc x -> acc ++ "/" ++ x) "/" parts
+  queryParamsLen :: Int <- choose (0,10)
+  queryParams <- replicateM queryParamsLen genQueryParam
+  let queryParamsStr = Prelude.foldl (\acc x -> acc ++ "&" ++ x) "?" queryParams
+  return $ pack $ prefix ++ domain ++ path ++ "?" ++ queryParamsStr
+  where
+
+  genFullDomain = do
+    len <- choose (1, 4)
+    subDomains <- replicateM len genSubDomain
+    return $ Prelude.foldl aggregate "" subDomains  ++ ".com"
+    where
+    aggregate "" x = x
+    aggregate acc y = acc ++ "." ++ y
+
+  genSubDomain = do
+    len <- choose (1, 4)
+    replicateM len (elements "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+
+  genPart = do
+    len <- choose (1, 15)
+    replicateM len (elements "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._")
+  genQueryParam = do
+    paramNameLen <- choose (1, 15)
+    paramName <- replicateM paramNameLen (elements alphaNum)
+    paramValueLen <- choose (1, 15)
+    paramValue <- replicateM paramValueLen (elements alphaNum)
+    return $ paramName ++ "=" ++ paramValue
+
+alphaNum :: [Char]
+alphaNum = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9']
+
+instance Arbitrary Website where
+  arbitrary = genPatternedTextWith genWebsite
+
+instance Arbitrary LinkedIn where
+  arbitrary = genPatternedTextWith genLinkedIn
+
+-- LinkedIn regex:
+-- ^(http(s)?:\/\/)?([\w]+\.)?linkedin\.com\/(pub|in|profile|company)\/([a-zA-Z0-9_-]+)$
+
+genLinkedIn :: Gen Text
+genLinkedIn = do
+  prefix <- elements ["https://", "http://"]
+  domain <- elements ["linkedin.com", "www.linkedin.com"]
+  suffix <- elements ["/pub/", "/in/", "/profile/", "/company/"]
+  account <- genLinkedInAccount
+  return $ pack $ prefix ++ domain ++ suffix ++ account
+  where
+  genLinkedInAccount = do
+    len <- choose (1, 15)
+    replicateM len (elements "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+
+instance Arbitrary Email where
+  arbitrary = genPatternedTextWith genEmail
+
+-- Email regex:
+-- "^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$"
+
+genEmail :: Gen Text
+genEmail = do
+  prefix <- replicateM 10 (elements (alphaNum ++ "_."))
+  domain <- replicateM 10 (elements (alphaNum ++ "_."))
+  suffix <- replicateM 3 (elements "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
+  return $ pack $ prefix ++ "@" ++ domain ++ "." ++ suffix
+
+
+genArbitraryName :: Gen Text
+genArbitraryName = do
+  len <- choose (1, 15)
+  pack <$> replicateM len (elements (alphaNum ++ "-_"))
+
+genMaybe :: Gen a -> Gen (Maybe a)
+genMaybe g = do
+  b <- arbitrary
+  if b then Just <$> g else return Nothing
+
+instance Arbitrary ProfileId where
+  arbitrary = toId . (+1) . abs <$> arbitrary
+
+instance Arbitrary Profile where
+  arbitrary = Profile (toId (-1))
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> genMaybe genArbitraryName
+    <*> genMaybe genArbitraryName
+
+instance Arbitrary DApp where
+  arbitrary = DApp (toId (-1))
+    <$> genArbitraryName
+    <*> genArbitraryName
+    <*> genArbitraryName
+    <*> genArbitraryName
+    <*> arbitrary
+
+instance Arbitrary DAppDTO where
+  arbitrary = DAppDTO <$> arbitrary
+
+instance Arbitrary ProfileDTO where
+  arbitrary = ProfileDTO
+    <$> arbitrary
+    <*> arbitrary
+
+instance Arbitrary ProfileBody where
+  arbitrary = ProfileBody <$> arbitrary <*> arbitrary

--- a/test/JSONSpec.hs
+++ b/test/JSONSpec.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+module JSONSpec (spec) where
+
+import Test.Hspec
+import IOHK.Certification.Persistence
+import Plutus.Certification.API
+import Utils.JSON
+
+
+import Instances.Persistence ()
+import Test.Hspec.QuickCheck (modifyMaxSuccess)
+import Data.Text (pack)
+
+na :: a
+na = undefined
+
+spec :: SpecWith ()
+spec = modifyMaxSuccess (const 2000) $ do
+  describe "JSON - happy path" $ do
+      testJSON (na :: GitHubAccessToken)
+      testJSON' "Twitter" (na :: Twitter)
+      testJSON' "LinkedIn" (na :: LinkedIn)
+      testJSON' "Email" (na :: Email)
+      modifyMaxSuccess (const 300) $ do
+        testJSON' "ProfileWalletAddress" (na :: ProfileWalletAddress)
+        testJSON' "Website" (na :: Website)
+      modifyMaxSuccess (const 200) $ do
+        testJSON' "Profile" (na :: Profile)
+        testJSON' "DApp" (na :: DApp)
+        testJSONWithEq' eqDAppDTO "DAppDTO" (na :: DAppDTO)
+        testJSONWithEq' eqProfileDTO "ProfileDTO" (na :: ProfileDTO)
+        testJSONWithEq' eqProfileBody "ProfileBody" (na :: ProfileBody)
+
+  where
+
+  dummyAddress :: ProfileWalletAddress
+  dummyAddress = case mkPatternedText $ "addr1" <> pack (replicate 58 '0') of
+    Right a -> a
+    Left _ -> error "dummyAddress"
+  eqProfileBody :: ProfileBody -> ProfileBody-> Bool
+  eqProfileBody (ProfileBody ap ad) (ProfileBody bp bd) =
+    let ap' = ap { ownerAddress = dummyAddress }
+        bp' = bp { ownerAddress = dummyAddress }
+    in ap' == bp' && ad == bd
+
+  eqProfileDTO :: ProfileDTO -> ProfileDTO -> Bool
+  eqProfileDTO (ProfileDTO ap ad) (ProfileDTO bp bd) = ap == bp && case (ad,bd) of
+    (Just a, Just b) -> eqDAppDTO a b
+    (Nothing, Nothing) -> True
+    _ -> False
+
+  eqDAppDTO :: DAppDTO -> DAppDTO -> Bool
+  eqDAppDTO (DAppDTO a) (DAppDTO b)
+    | a == b = True
+    | otherwise = case (dappGitHubToken a,dappGitHubToken b) of
+      (Just _, Nothing) -> a { dappGitHubToken = Nothing } == b
+      (Nothing,Just _) -> a == b { dappGitHubToken = Nothing}
+      _ -> False
+
+

--- a/test/PatternSpec.hs
+++ b/test/PatternSpec.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications  #-}
+module PatternSpec (spec) where
+
+import Test.Hspec
+import IOHK.Certification.Persistence
+import Data.Aeson
+import Data.Text
+import Instances.Persistence ()
+import Data.Text.Encoding (encodeUtf8)
+import Test.QuickCheck
+import Test.Hspec.QuickCheck
+
+newtype InvalidAddressChar = InvalidAddressChar Char
+  deriving (Show, Eq)
+
+instance Arbitrary InvalidAddressChar where
+  arbitrary = InvalidAddressChar <$> elements "?!@#$%^&*()}{\\|][<>~`}"
+
+newtype LongerAddressLength = LongerAddressLength Int
+  deriving (Show, Eq)
+
+instance Arbitrary LongerAddressLength where
+  arbitrary = LongerAddressLength <$> choose (99,120)
+
+newtype ShorterAddressLength = ShorterAddressLength Int
+  deriving (Show, Eq)
+
+instance Arbitrary ShorterAddressLength where
+  arbitrary = ShorterAddressLength <$> choose (0,52)
+
+encodedProfileAddress tokenStr = eitherDecodeStrict
+  @ProfileWalletAddress (encodeUtf8 ("\"" <> tokenStr <> "\""))
+spec :: SpecWith ()
+spec =
+  describe "Persistence data validations" $ do
+
+      describe "GitHubAccessToken" $ do
+
+        it "should succeed on decoding valid token" $ do
+          let token = "\"ghp_000000000000000000000000000000000000\""
+          decode token `shouldBe` Just (GitHubAccessToken PersonalToken "000000000000000000000000000000000000")
+
+        it "should fail on decoding invalid token because of prefix" $ do
+          let token = "\"ghX_000000000000000000000000000000000000\""
+          eitherDecode token
+            `shouldBe`
+            (Left "Error in $: invalid access token type" :: Either String GitHubAccessToken)
+
+        it "should fail on decoding invalid token because of suffix" $ do
+          let token = "\"ghp_!@#@#@%#@$%@#%@#$%@\""
+          eitherDecode token
+            `shouldBe`
+            (Left "Error in $: invalid suffix" :: Either String GitHubAccessToken)
+
+        it "should fail on decoding invalid token" $ do
+          let token = "\"asdadas\""
+          eitherDecode token
+            `shouldBe`
+            (Left "Error in $: invalid token" :: Either String GitHubAccessToken)
+
+      describe "ProfileWalletAddress JSON encode/decode" $ do
+
+        let token = "qrh2dmheg8mnxjzrw0muya97x2adhyyesqmqahhjswkjh8yg672ldf7xjwvpv77022vxtjy33g7luypk2wygaqst3r7qxu0fd2"
+        let stakeToken = "urdyxqs76a3zcwjpkym0kc2xsq26elcartf5gcmp0gn58ms32qx04"
+
+        it "should fail on \"\"" $
+          decode "" `shouldBe` (Nothing :: Maybe ProfileWalletAddress)
+
+        it "should decode correctly for change address on mainnet" $ do
+          let fullTokenStr =  "addr1" <> token
+          (show <$> encodedProfileAddress fullTokenStr)
+            `shouldBe` Right (show fullTokenStr)
+
+        it "should decode correctly for change address on testnet" $ do
+          let fullTokenStr =  "addr_test1" <> token
+          (show <$> encodedProfileAddress fullTokenStr)
+            `shouldBe` Right (show fullTokenStr)
+
+        it "should decode correctly for stake address on mainnet" $ do
+          let fullTokenStr =  "stake" <> stakeToken
+          (show <$> encodedProfileAddress fullTokenStr)
+            `shouldBe` Right (show fullTokenStr)
+
+        it "should decode correctly for stake address on testnet" $ do
+          let fullTokenStr =  "stake_test1" <> stakeToken
+          (show <$> encodedProfileAddress fullTokenStr)
+            `shouldBe` Right (show fullTokenStr)
+
+        prop "should fail on short address" $ \(ShorterAddressLength n) -> do
+          let _shortText = pack $ Prelude.replicate n '0'
+          decodeStrict (encodeUtf8 $ "\"addr1" <> _shortText  <> "\"")
+          `shouldBe`
+          (Nothing :: Maybe ProfileWalletAddress)
+
+        prop "should fail on invalid characters" $ \(InvalidAddressChar c) -> do
+          let _99LongText = pack $ Prelude.replicate 98 c
+          decodeStrict (encodeUtf8 $ "\"addr1" <> _99LongText <> "\"")
+          `shouldBe`
+          (Nothing :: Maybe ProfileWalletAddress)

--- a/test/ProfileWalletSpec.hs
+++ b/test/ProfileWalletSpec.hs
@@ -56,9 +56,12 @@ fromDbTransactionSpec =
                 False
             ]
       let resp = fromDbTransaction isOurAddress 0 tx entries
+      payer' <- case mkPatternedText payer :: Either String ProfileWalletAddress of
+            Right x -> pure x
+            Left _ -> fail "Failed to create ProfileWalletAddress"
       resp `shouldBe`
         Right (DesignatedPayment
-                (ProfileAddress payer)
+                payer'
                 (WalletAddress walletAddress)
                 (fromIntegral amount))
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,8 +1,12 @@
 import Test.Hspec
 import qualified ProfileWalletSpec as ProfileWallet
 import qualified SignatureSpec as Signature
+import qualified PatternSpec as Pattern
+import qualified JSONSpec as JSON
 
 main :: IO ()
 main = hspec $ do
   ProfileWallet.spec
   Signature.spec
+  Pattern.spec
+  JSON.spec

--- a/test/Utils/JSON.hs
+++ b/test/Utils/JSON.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+module Utils.JSON where
+
+import Data.Data
+import Data.Aeson
+import Data.Aeson.Encode.Pretty
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+import Debug.Trace
+import Data.ByteString.Lazy.Char8 hiding (replicate,length)
+
+traceError :: Show a => [Char] -> a -> [Char] -> [Char] -> Bool
+traceError propS x err info =
+  trace ("ERROR "++ propS ++"\n\t" ++ show x ++ ":\n\t" ++ err ++ "\n" ++ info ++ "\n\n\n") False
+
+testJSON :: (Data a,Show a,Arbitrary a,ToJSON a,FromJSON a,Eq a)=> a -> SpecWith ()
+testJSON = testJSONWithEq (==)
+
+testJSONWithEq :: (Data a,Show a,Arbitrary a,ToJSON a,FromJSON a)=> EqF a -> a -> SpecWith ()
+testJSONWithEq eq a = prop (fmt a) (jsonT eq a)
+
+testJSON' :: (Show a,Arbitrary a,ToJSON a,FromJSON a,Eq a)=> String -> a -> SpecWith ()
+testJSON' = testJSONWithEq' (==)
+
+testJSONWithEq' :: (Show a,Arbitrary a,ToJSON a,FromJSON a)=> EqF a -> String -> a -> SpecWith ()
+testJSONWithEq' eq title a = prop (padL 30 title) (jsonT eq a)
+
+fmt :: Data a => a -> String
+fmt x = padL 30 (dataTypeName $ dataTypeOf x)
+
+padL :: Int -> String -> String
+padL n s
+    | length s < n  = s ++ replicate (n - length s) ' '
+    | otherwise     = s
+
+type EqF a = a -> a -> Bool
+
+traceEq :: (Show a) => EqF a -> a -> a -> Bool
+traceEq eq x y = (x `eq` y) || trace (show x ++ "\n\n" ++ show y) False
+
+jsonT :: (Show a,Arbitrary a,ToJSON a,FromJSON a) => EqF a -> a -> a -> Bool
+jsonT eq _ x =
+    let bs = encodePretty x
+        str = unpack bs
+        yE = eitherDecode bs
+    in case yE of
+           Right y -> traceEq eq x y
+           Left err ->
+            traceError "jsonT" x err str
+
+


### PR DESCRIPTION
Fixes [PLT-6187](https://input-output.atlassian.net/browse/PLT-6187)
Fixes [PLT-7408](https://input-output.atlassian.net/browse/PLT-7408)

Summary:

- Modifies/Adds different user details to `Profile`
- Add Pattern(Regex) validation for these fields
- Creates a unique dependent type `PatternedText` encapsulating the regex pattern within the type definition
- Changing `Twitter`,`LinkedIn`,`Website`, etc as aliases for `PatternText`
- Uses these types directly as Selda table fields
- A lot of refactoring involving these changes
- Adding unit tests and property testing regarding these types serialization
