### PR TITLE
Add run-certify to the docker image.

### DIFF
--- a/nix/docker-files/docker.nix
+++ b/nix/docker-files/docker.nix
@@ -1,7 +1,7 @@
 { inputs, pkgs, lib, ... }: let
     imgAttributes = {
       name = "plutus-certification";
-      tag = "24";
+      tag = "25";
     };
     nixConfig = ''
         trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
@@ -112,15 +112,14 @@
       finalImageName = "nixos/nix";
       finalImageTag = "2.15.0";
     };
-    genFlake = inputs.self.packages.generate-flake;
-    buildFlake = inputs.self.packages.build-flake;
+    inherit (inputs.self.packages) generate-flake build-flake run-certify;
     image = pkgs.dockerTools.buildImage (imgAttributes // {
       fromImage = nixImage;
       diskSize = 5120;
       #contents = [ pkgs.hello ];
       copyToRoot = pkgs.buildEnv {
         name = "image-root";
-        paths = [ pkgs.curl pkgs.zsh pkgs.coreutils pkgs.nmon pkgs.cacert genFlake buildFlake ];
+        paths = [ pkgs.curl pkgs.zsh pkgs.coreutils pkgs.nmon pkgs.cacert generate-flake build-flake run-certify ];
         pathsToLink = [ "/bin" ];
       };
        runAsRoot = ''


### PR DESCRIPTION
This will allow reusing it for the workflow scheduler.

In the future we will want a separate container for this, but this will get us started.